### PR TITLE
Rebuild static pages with shared blue theme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy static site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# InnovacionSindical
-Pagina del proyecto Innovación Sindical 
+# Innovación Sindical
+
+Sitio web estático en tonos azules con página principal, sección "¿Quiénes somos?" y formulario de registro para la iniciativa Innovación Sindical.
+
+## Estructura
+
+- `index.html`: landing page con hero, métricas, soluciones y llamado a la acción.
+- `quienes-somos.html`: misión, visión, valores, hitos y equipo.
+- `registro.html`: formulario detallado para incorporar sindicatos.
+- `assets/styles.css`: hoja de estilos compartida para todas las páginas.
+
+## Publicación en GitHub Pages
+
+El repositorio incluye un flujo de trabajo de GitHub Actions (`.github/workflows/deploy.yml`) que publica automáticamente el sitio en GitHub Pages cada vez que se hace push a la rama `main`.
+
+1. En GitHub ve a **Settings → Pages** y selecciona **GitHub Actions** como fuente.
+2. Confirma que la rama principal se llama `main`. Si estás trabajando en otra rama, haz merge a `main`.
+3. Desde tu entorno local ejecuta:
+   ```bash
+   git add .
+   git commit -m "Describe tus cambios"
+   git push origin main
+   ```
+4. GitHub Actions ejecutará el workflow **Deploy static site** y, al finalizar, mostrará la URL pública en la sección de deployments.
+5. Comparte la URL generada; tu sitio estará disponible en unos minutos.
+
+## Vista previa local
+
+Para revisar los cambios antes de publicarlos puedes levantar un servidor estático simple:
+
+```bash
+python -m http.server 8000
+```
+
+Luego abre <http://localhost:8000/index.html> en tu navegador.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,447 @@
+:root {
+  --color-bg: #f5f9ff;
+  --color-surface: #ffffff;
+  --color-primary: #2563eb;
+  --color-primary-dark: #1d4ed8;
+  --color-primary-light: #60a5fa;
+  --color-text: #0f172a;
+  --color-muted: #475569;
+  --color-border: #e2e8f0;
+  --shadow-lg: 0 24px 48px rgba(37, 99, 235, 0.15);
+  --shadow-md: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--color-primary);
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+header {
+  background: linear-gradient(110deg, rgba(37, 99, 235, 0.1), rgba(14, 116, 144, 0.05));
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(37, 99, 235, 0.1);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-primary);
+}
+
+.brand-symbol {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-light));
+  color: white;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.3);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.75rem;
+  align-items: center;
+}
+
+nav a {
+  text-decoration: none;
+  font-weight: 500;
+  color: var(--color-muted);
+  transition: color 0.2s ease;
+}
+
+nav a.active, nav a:hover {
+  color: var(--color-primary);
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: white;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--shadow-md);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border);
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.7);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-outline:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.hero {
+  padding: clamp(3rem, 8vw, 6rem) 0 4rem;
+}
+
+.hero-grid {
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 4vw, 3.75rem);
+  line-height: 1.15;
+  margin-bottom: 1.5rem;
+}
+
+.hero p {
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.metric-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(37, 99, 235, 0.08);
+}
+
+.metric-card span {
+  display: block;
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  margin-bottom: 1rem;
+}
+
+.section p.section-lead {
+  color: var(--color-muted);
+  max-width: 640px;
+  margin-bottom: 2.5rem;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 1rem;
+}
+
+.card h3 {
+  font-size: 1.25rem;
+}
+
+.card p {
+  color: var(--color-muted);
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.75rem;
+}
+
+.step {
+  background: var(--color-surface);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid rgba(37, 99, 235, 0.1);
+  box-shadow: var(--shadow-md);
+}
+
+.step span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.cta {
+  background: linear-gradient(120deg, rgba(37, 99, 235, 0.12), rgba(96, 165, 250, 0.12));
+  border-radius: 2rem;
+  padding: clamp(2.5rem, 4vw, 3.5rem);
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  text-align: center;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2.5rem 0;
+  margin-top: auto;
+}
+
+footer .footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+footer p {
+  color: #cbd5f5;
+}
+
+footer a {
+  color: #e2e8f0;
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: #60a5fa;
+}
+
+/* Quiénes somos */
+
+.banner {
+  background: linear-gradient(120deg, rgba(37, 99, 235, 0.2), rgba(59, 130, 246, 0.15));
+  border-radius: 2rem;
+  padding: clamp(3rem, 8vw, 4.5rem);
+  text-align: center;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  margin-bottom: 3rem;
+}
+
+.values-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+}
+
+.value-card {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  box-shadow: var(--shadow-md);
+}
+
+.timeline {
+  position: relative;
+  margin-top: 3rem;
+  padding-left: 1.5rem;
+  border-left: 2px solid rgba(37, 99, 235, 0.2);
+  display: grid;
+  gap: 2rem;
+}
+
+.timeline-item {
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -1.95rem;
+  top: 0.5rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.15);
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+}
+
+.team-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
+}
+
+/* Registro */
+
+.registration-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(2rem, 5vw, 3rem);
+  align-items: start;
+  padding: clamp(3rem, 7vw, 4.5rem) 0 4rem;
+}
+
+.form-card {
+  background: var(--color-surface);
+  border-radius: 1.75rem;
+  padding: clamp(2rem, 4vw, 2.75rem);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.65rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: #f8fbff;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.form-note {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.benefits {
+  background: linear-gradient(130deg, rgba(37, 99, 235, 0.18), rgba(96, 165, 250, 0.12));
+  border-radius: 2rem;
+  padding: clamp(2.5rem, 4vw, 3.25rem);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid rgba(37, 99, 235, 0.16);
+}
+
+.benefits ul {
+  list-style: none;
+  display: grid;
+  gap: 1.25rem;
+  color: #0f172a;
+}
+
+.benefits strong {
+  color: var(--color-primary-dark);
+}
+
+@media (max-width: 720px) {
+  nav ul {
+    gap: 1rem;
+  }
+
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  footer .footer-grid {
+    gap: 1rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Innovación Sindical</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <a class="brand" href="index.html">
+        <span class="brand-symbol">IS</span>
+        Innovación Sindical
+      </a>
+      <nav>
+        <ul>
+          <li><a class="active" href="index.html">Inicio</a></li>
+          <li><a href="quienes-somos.html">¿Quiénes somos?</a></li>
+          <li><a href="registro.html">Registro</a></li>
+          <li><a class="btn-primary" href="registro.html">Únete ahora</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <h1>Renovamos la experiencia sindical con tecnología humana</h1>
+          <p>
+            Conecta, organiza y potencia tu sindicato con herramientas digitales
+            diseñadas para fortalecer la participación, la transparencia y la toma de decisiones.
+          </p>
+          <div class="cta-group">
+            <a class="btn-primary" href="registro.html">Crear cuenta</a>
+            <a class="btn-outline" href="quienes-somos.html">Conocer más</a>
+          </div>
+        </div>
+        <div class="metrics">
+          <article class="metric-card">
+            <span>+120</span>
+            Sindicatos colaborando con nosotros en América Latina.
+          </article>
+          <article class="metric-card">
+            <span>95%</span>
+            De satisfacción en procesos de afiliación y comunicación interna.
+          </article>
+          <article class="metric-card">
+            <span>24/7</span>
+            Acceso seguro a datos, reportes y seguimiento en la nube.
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="soluciones">
+      <div class="container">
+        <h2>Soluciones pensadas para el día a día sindical</h2>
+        <p class="section-lead">
+          Simplificamos la gestión operativa mientras potenciamos la participación de las bases.
+          Todo en un ecosistema conectado, seguro y listo para crecer contigo.
+        </p>
+        <div class="cards-grid">
+          <article class="card">
+            <h3>Afiliación inteligente</h3>
+            <p>
+              Formularios digitales, verificación automática y seguimiento de solicitudes en tiempo real.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Participación activa</h3>
+            <p>
+              Votaciones virtuales, encuestas seguras y espacios colaborativos para deliberar.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Gestión transparente</h3>
+            <p>
+              Paneles de control con métricas clave, reportes auditables y trazabilidad completa.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Acompañamiento experto</h3>
+            <p>
+              Equipo multidisciplinario para implementar, capacitar y medir resultados desde el primer día.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="como-funciona">
+      <div class="container">
+        <h2>Implementación ágil en cuatro pasos</h2>
+        <p class="section-lead">
+          Nuestro equipo acompaña cada etapa para que tu organización adopte la plataforma sin fricciones.
+        </p>
+        <div class="steps">
+          <article class="step">
+            <span>01</span>
+            <h3>Diagnóstico colaborativo</h3>
+            <p>
+              Analizamos procesos actuales y definimos objetivos junto a representantes y afiliados.
+            </p>
+          </article>
+          <article class="step">
+            <span>02</span>
+            <h3>Configuración personalizada</h3>
+            <p>
+              Ajustamos módulos, permisos y flujos a la realidad de cada sindicato sin código adicional.
+            </p>
+          </article>
+          <article class="step">
+            <span>03</span>
+            <h3>Capacitación integral</h3>
+            <p>
+              Talleres prácticos, tutoriales y soporte continuo para delegados, directivos y afiliados.
+            </p>
+          </article>
+          <article class="step">
+            <span>04</span>
+            <h3>Medición y mejora</h3>
+            <p>
+              Seguimiento trimestral de indicadores para asegurar impacto sostenible en la organización.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container cta">
+        <h2>Listos para impulsar el futuro de tu sindicato</h2>
+        <p>
+          Agenda una demo personalizada y descubre cómo Innovación Sindical puede ayudarte a conectar con tus afiliados.
+        </p>
+        <a class="btn-primary" href="registro.html">Solicitar demo</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <strong>Innovación Sindical</strong>
+        <p>Plataforma integral para organizaciones sindicales modernas.</p>
+      </div>
+      <div>
+        <strong>Navegación</strong>
+        <p><a href="index.html">Inicio</a></p>
+        <p><a href="quienes-somos.html">¿Quiénes somos?</a></p>
+        <p><a href="registro.html">Registro</a></p>
+      </div>
+      <div>
+        <strong>Contacto</strong>
+        <p>hola@innovacionsindical.org</p>
+        <p>+54 9 11 5555-0000</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/quienes-somos.html
+++ b/quienes-somos.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>¿Quiénes somos? | Innovación Sindical</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <a class="brand" href="index.html">
+        <span class="brand-symbol">IS</span>
+        Innovación Sindical
+      </a>
+      <nav>
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a class="active" href="quienes-somos.html">¿Quiénes somos?</a></li>
+          <li><a href="registro.html">Registro</a></li>
+          <li><a class="btn-primary" href="registro.html">Únete ahora</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="container">
+        <div class="banner">
+          <h1>Transformamos la representación sindical con innovación y empatía</h1>
+          <p>
+            Somos un equipo de especialistas en tecnología, gestión sindical y participación ciudadana que acompaña a las organizaciones a modernizar sus procesos sin perder su esencia.
+          </p>
+        </div>
+
+        <section class="section">
+          <h2>Nuestra misión y visión</h2>
+          <p class="section-lead">
+            Creemos que la tecnología es una herramienta para acercar a las personas, transparentar decisiones y fortalecer la negociación colectiva.
+          </p>
+          <div class="values-grid">
+            <article class="value-card">
+              <h3>Misión</h3>
+              <p>
+                Facilitar la transformación digital de los sindicatos mediante soluciones accesibles, seguras y orientadas a resultados.
+              </p>
+            </article>
+            <article class="value-card">
+              <h3>Visión</h3>
+              <p>
+                Ser la plataforma de referencia en Latinoamérica para organizaciones sindicales más conectadas, diversas y participativas.
+              </p>
+            </article>
+            <article class="value-card">
+              <h3>Valores</h3>
+              <p>
+                Construimos con transparencia, colaboración, respeto por la diversidad y foco en las personas afiliadas.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Hitos que marcan nuestro camino</h2>
+          <div class="timeline">
+            <article class="timeline-item">
+              <h3>2018 · Primer piloto colaborativo</h3>
+              <p>
+                Lanzamos un prototipo junto a tres sindicatos para digitalizar actas y padrones en tiempo real.
+              </p>
+            </article>
+            <article class="timeline-item">
+              <h3>2020 · Plataforma en la nube</h3>
+              <p>
+                Incorporamos módulos de votaciones virtuales, comunicación segmentada y analítica de participación.
+              </p>
+            </article>
+            <article class="timeline-item">
+              <h3>2022 · Alianzas regionales</h3>
+              <p>
+                Expansión a cinco países con programas de capacitación y acompañamiento en territorios.
+              </p>
+            </article>
+            <article class="timeline-item">
+              <h3>2024 · Laboratorio de innovación sindical</h3>
+              <p>
+                Creamos un espacio de co-creación con delegados y delegadas para experimentar nuevas herramientas.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Equipo interdisciplinario</h2>
+          <p class="section-lead">
+            Reunimos perfiles complementarios para acompañar a cada organización con una mirada integral.
+          </p>
+          <div class="team-grid">
+            <article class="team-card">
+              <h3>Laura Fernández</h3>
+              <p>Directora ejecutiva · 12 años en conducción sindical y negociación colectiva.</p>
+            </article>
+            <article class="team-card">
+              <h3>Diego Ramírez</h3>
+              <p>Líder tecnológico · Arquitecto de software especializado en plataformas cívicas.</p>
+            </article>
+            <article class="team-card">
+              <h3>Camila Duarte</h3>
+              <p>Responsable de comunidad · Diseña programas de capacitación y participación territorial.</p>
+            </article>
+            <article class="team-card">
+              <h3>Alianzas estratégicas</h3>
+              <p>Red de consultores legales, comunicadores y especialistas en seguridad de la información.</p>
+            </article>
+          </div>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <strong>Innovación Sindical</strong>
+        <p>Plataforma integral para organizaciones sindicales modernas.</p>
+      </div>
+      <div>
+        <strong>Navegación</strong>
+        <p><a href="index.html">Inicio</a></p>
+        <p><a href="quienes-somos.html">¿Quiénes somos?</a></p>
+        <p><a href="registro.html">Registro</a></p>
+      </div>
+      <div>
+        <strong>Contacto</strong>
+        <p>hola@innovacionsindical.org</p>
+        <p>+54 9 11 5555-0000</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/registro.html
+++ b/registro.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Registro | Innovación Sindical</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body>
+  <header>
+    <div class="container header-inner">
+      <a class="brand" href="index.html">
+        <span class="brand-symbol">IS</span>
+        Innovación Sindical
+      </a>
+      <nav>
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="quienes-somos.html">¿Quiénes somos?</a></li>
+          <li><a class="active" href="registro.html">Registro</a></li>
+          <li><a class="btn-primary" href="#formulario">Únete ahora</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="registration-hero">
+      <div class="container">
+        <div class="hero-grid">
+          <div class="benefits">
+            <h1>Comienza a transformar tu sindicato hoy</h1>
+            <p>
+              Completa el formulario y recibe acceso a nuestra plataforma junto con un plan de implementación guiada.
+            </p>
+            <ul>
+              <li><strong>Implementación guiada:</strong> sesiones con especialistas para configurar cada módulo.</li>
+              <li><strong>Seguridad y cumplimiento:</strong> infraestructura protegida y políticas de privacidad claras.</li>
+              <li><strong>Participación real:</strong> herramientas para mantener informada y activa a toda la base.</li>
+            </ul>
+          </div>
+
+          <form id="formulario" class="form-card">
+            <h2>Registro de organización</h2>
+            <p class="form-note">
+              Nuestro equipo se pondrá en contacto en menos de 48 horas para confirmar la activación de tu cuenta.
+            </p>
+            <div class="form-grid">
+              <div>
+                <label for="nombre-sindicato">Nombre del sindicato</label>
+                <input id="nombre-sindicato" name="nombre-sindicato" type="text" placeholder="Sindicato de ejemplo" required />
+              </div>
+              <div>
+                <label for="sector">Sector</label>
+                <select id="sector" name="sector" required>
+                  <option value="">Selecciona un sector</option>
+                  <option>Educación</option>
+                  <option>Salud</option>
+                  <option>Transporte</option>
+                  <option>Industria</option>
+                  <option>Servicios públicos</option>
+                  <option>Otro</option>
+                </select>
+              </div>
+              <div>
+                <label for="cantidad-afiliados">Cantidad de afiliados</label>
+                <select id="cantidad-afiliados" name="cantidad-afiliados" required>
+                  <option value="">Selecciona un rango</option>
+                  <option>- 500</option>
+                  <option>500 - 2.000</option>
+                  <option>2.000 - 10.000</option>
+                  <option>+ 10.000</option>
+                </select>
+              </div>
+              <div>
+                <label for="pais">País</label>
+                <input id="pais" name="pais" type="text" placeholder="Argentina" required />
+              </div>
+              <div>
+                <label for="nombre-contacto">Nombre de contacto</label>
+                <input id="nombre-contacto" name="nombre-contacto" type="text" placeholder="Nombre y apellido" required />
+              </div>
+              <div>
+                <label for="correo">Correo electrónico</label>
+                <input id="correo" name="correo" type="email" placeholder="correo@organizacion.org" required />
+              </div>
+              <div>
+                <label for="telefono">Teléfono</label>
+                <input id="telefono" name="telefono" type="tel" placeholder="Código de país + número" required />
+              </div>
+              <div>
+                <label for="cargo">Cargo / Rol</label>
+                <input id="cargo" name="cargo" type="text" placeholder="Secretaría General, Delegado/a" />
+              </div>
+            </div>
+            <div>
+              <label for="objetivos">Objetivos principales</label>
+              <textarea id="objetivos" name="objetivos" placeholder="Cuéntanos qué necesitas mejorar en tu organización"></textarea>
+            </div>
+            <button class="btn-primary" type="submit">Enviar registro</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <strong>Innovación Sindical</strong>
+        <p>Plataforma integral para organizaciones sindicales modernas.</p>
+      </div>
+      <div>
+        <strong>Navegación</strong>
+        <p><a href="index.html">Inicio</a></p>
+        <p><a href="quienes-somos.html">¿Quiénes somos?</a></p>
+        <p><a href="registro.html">Registro</a></p>
+      </div>
+      <div>
+        <strong>Contacto</strong>
+        <p>hola@innovacionsindical.org</p>
+        <p>+54 9 11 5555-0000</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the landing page with a lighter blue palette, shared navigation, and updated sections for metrics, soluciones y CTA
- update the "¿Quiénes somos?" and registro pages to match the new visual system with claros hitos, equipo y formulario simplificado
- centralize estilos in `assets/styles.css` y documentar pasos para publicar con GitHub Pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2ea1ab0908328ba2375d6b24c5bdb