### PR TITLE
Theme: switch to green palette, UI polish and iframe external-app handling

### DIFF
--- a/admin_nucleo.html
+++ b/admin_nucleo.html
@@ -6,13 +6,13 @@
   <title>Control Central - Validación</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/@phosphor-icons/web"></script>
-  
+
   <style>
     :root {
-      --bg-body: #1b2e45; --panel-base: 46, 79, 119;
-      --primary: #4da1a8; --primary-light: #7ad1d6;
+      --bg-body: #004b33; --panel-base: 46, 79, 119;
+      --primary: #006341; --primary-light: #8fd9b6;
       --text-main: #f0fdfa; --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35); --radius: 12px;
+      --ring: rgba(0, 99, 65, .35); --radius: 12px;
     }
     body { background-color: var(--bg-body); color: var(--text-main); font-family: 'Inter', sans-serif; padding: 20px; }
     .container { max-width: 800px; margin: 0 auto; }
@@ -70,7 +70,7 @@
               <h3 style="margin: 0; color: var(--primary-light);">${item.nombre_delegacion}</h3>
               <p style="margin: 8px 0; font-weight: 600; font-size: 18px;">${item.titulo_conflicto}</p>
               <p style="margin: 0 0 12px 0; font-size: 14px; color: var(--text-muted);">${item.descripcion}</p>
-              <span style="background: rgba(77,161,168,0.2); padding: 4px 8px; border-radius: 4px; font-size: 12px;">Categoría: ${item.categoria}</span>
+              <span style="background: rgba(0,99,65,0.2); padding: 4px 8px; border-radius: 4px; font-size: 12px;">Categoría: ${item.categoria}</span>
             </div>
           </div>
           <div style="margin-top: 20px; border-top: 1px solid var(--ring); padding-top: 16px; display: flex; align-items: center; justify-content: space-between;">
@@ -98,7 +98,7 @@
       if (error) {
         alert("Hubo un error al actualizar.");
       } else {
-        cargarPendientes(); 
+        cargarPendientes();
       }
     }
 

--- a/assets/app.css
+++ b/assets/app.css
@@ -1,8 +1,8 @@
 ```css
 :root{
---bg:#0b1022; --fg:#e6fbff; --muted:#b9d8e0; --panel:rgba(7,17,35,.78);
---edge:rgba(91,215,242,.35); --edge-soft:rgba(255,255,255,.12);
---accent:#5bd7f2; --ok:#00d19a; --err:#ff6b6b; --shadow:0 10px 30px rgba(0,0,0,.35);
+--bg:#032a1d; --fg:#e6fbff; --muted:#b9d8e0; --panel:rgba(7,17,35,.78);
+--edge:rgba(0,168,107,.35); --edge-soft:rgba(255,255,255,.12);
+--accent:#00a86b; --ok:#00d19a; --err:#ff6b6b; --shadow:0 10px 30px rgba(0,0,0,.35);
 --radius-xl:18px; --radius-lg:14px;
 }
 *{box-sizing:border-box}
@@ -14,13 +14,13 @@ body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,
 background:radial-gradient(1200px 600px at 10% 10%, rgba(13,74,118,.45), transparent 65%),
 radial-gradient(900px 500px at 80% 0%, rgba(12,47,82,.45), transparent 60%),
 radial-gradient(1000px 700px at 50% 90%, rgba(7,36,63,.5), transparent 70%),
-#020b1f;filter:saturate(110%)}
+#022517;filter:saturate(110%)}
 
 
 .wrap{max-width:1000px;margin:32px auto;padding:24px}
 .topbar{display:flex;gap:12px;align-items:center;justify-content:space-between;margin-bottom:16px}
 .brand{display:flex;align-items:center;gap:12px}
-.brand .logo{width:36px;height:36px;display:inline-grid;place-items:center;border-radius:12px;background:linear-gradient(135deg, rgba(91,215,242,.25), rgba(91,215,242,.05));border:1px solid var(--edge)}
+.brand .logo{width:36px;height:36px;display:inline-grid;place-items:center;border-radius:12px;background:linear-gradient(135deg, rgba(0,168,107,.25), rgba(0,168,107,.05));border:1px solid var(--edge)}
 .brand h1{margin:0;font-size:18px;letter-spacing:.3px;font-weight:600}
 
 

--- a/auditoria.html
+++ b/auditoria.html
@@ -8,21 +8,21 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css" />
-  
+
   <style>
     :root {
       --bg-body: transparent;
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; 
-      --primary-light: #7ad1d6;
+      --primary: #006341;
+      --primary-light: #8fd9b6;
       --success: #4ade80;
       --warning: #fbbf24;
       --danger: #ff7b7b;
-      --text-main: #f0fdfa; 
+      --text-main: #f0fdfa;
       --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
     }
-    
+
     body { margin: 0; padding: 24px; background-color: var(--bg-body); color: var(--text-main); font-family: 'Inter', sans-serif; box-sizing: border-box; }
     * { box-sizing: border-box; }
 
@@ -42,10 +42,10 @@
     .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
     .stat-card { background: rgba(var(--panel-base), 0.4); border: 1px solid var(--ring); border-radius: 16px; padding: 20px; display: flex; align-items: center; gap: 16px; box-shadow: 0 8px 25px rgba(0,0,0,0.15); }
     .stat-card .icon { font-size: 42px; padding: 12px; border-radius: 12px; display: flex; align-items: center; justify-content: center; }
-    .stat-card.total .icon { color: var(--primary-light); background: rgba(77, 161, 168, 0.15); }
+    .stat-card.total .icon { color: var(--primary-light); background: rgba(0, 99, 65, 0.15); }
     .stat-card.pending .icon { color: var(--danger); background: rgba(255, 123, 123, 0.15); }
     .stat-card.resolved .icon { color: var(--success); background: rgba(74, 222, 128, 0.15); }
-    
+
     .stat-info h3 { margin: 0 0 4px 0; font-size: 32px; font-weight: 800; color: var(--text-main); line-height: 1; }
     .stat-info p { margin: 0; font-size: 13px; color: var(--text-muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;}
 
@@ -53,10 +53,10 @@
     .cartera-list { display: flex; flex-direction: column; gap: 12px; }
     .cartera-item { background: rgba(21, 35, 54, 0.6); border: 1px solid var(--ring); border-radius: 12px; padding: 20px; transition: all 0.2s; position: relative; overflow: hidden; }
     .cartera-item:hover { background: rgba(var(--panel-base), 0.5); border-color: var(--primary-light); transform: translateX(4px); }
-    
+
     .cartera-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; flex-wrap: wrap; gap: 12px;}
     .cartera-title { margin: 0; font-size: 16px; font-weight: 700; color: var(--text-main); display: flex; align-items: center; gap: 8px;}
-    
+
     .cartera-badges { display: flex; gap: 8px; }
     .c-badge { padding: 6px 12px; border-radius: 8px; font-size: 12px; font-weight: 700; display: flex; align-items: center; gap: 6px; }
     .c-badge.total { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: var(--text-main); }
@@ -122,7 +122,7 @@
     <h3 style="margin: 0 0 16px 0; font-size: 18px; color: var(--primary-light); display: flex; align-items: center; gap: 8px;">
       <i class="ph-duotone ph-users-three"></i> Desglose por Cartera Comunitaria
     </h3>
-    
+
     <div class="cartera-list" id="lista-carteras">
       </div>
   </div>
@@ -131,16 +131,16 @@
   <script>
     const SUPABASE_URL = "https://axsncdwshdvsysrpikwj.supabase.co";
     const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF4c25jZHdzaGR2c3lzcnBpa3dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyMjkwMjQsImV4cCI6MjA3NTgwNTAyNH0.oapcH219puVjaR2DcG7dX51uhwVn530L1hhz8ASv7qs";
-    
+
     let supabaseApp = null;
 
     async function init() {
       try {
-        if (window.parent && window.parent.supabaseClient) { supabaseApp = window.parent.supabaseClient; } 
-        else if (window.supabase) { supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } 
-        
+        if (window.parent && window.parent.supabaseClient) { supabaseApp = window.parent.supabaseClient; }
+        else if (window.supabase) { supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); }
+
         const { data: { session }, error } = await supabaseApp.auth.getSession();
-        
+
         if (error || !session) {
           mostrarBloqueo();
           return;
@@ -149,10 +149,10 @@
         // VERIFICACIÓN DE SEGURIDAD ESTRICTA
         const email = session.user.email;
         const correosAutorizados = ['s.general@seccionxx.mx', 's.interior@seccionxx.mx', 'c.vigilancia@seccionxx.mx'];
-        
+
         // Revisamos si es un correo autorizado o si es el super admin (cuenta sin dominio seccionxx)
         const { data: prof } = await supabaseApp.from('profiles').select('role').eq('user_id', session.user.id).maybeSingle();
-        
+
         const isSuperAdmin = prof && prof.role === 'admin' && !email.includes('@seccionxx.mx');
         const isAuthorizedEmail = correosAutorizados.includes(email);
 
@@ -193,13 +193,13 @@
         data.forEach(item => {
           totalGlobal++;
           const area = item.area_destino || 'Área Desconocida';
-          
+
           if(!mapCarteras[area]) {
             mapCarteras[area] = { total: 0, enviado: 0, proceso: 0, atendido: 0 };
           }
-          
+
           mapCarteras[area].total++;
-          
+
           if(item.estatus === 'Atendido') {
             mapCarteras[area].atendido++;
             atendidosGlobal++;
@@ -237,7 +237,7 @@
         arrayCarteras.forEach(c => {
           const s = c.stats;
           const rezago = s.enviado + s.proceso;
-          
+
           // Porcentajes para la barra
           const pctAtendido = s.total > 0 ? (s.atendido / s.total) * 100 : 0;
           const pctProceso = s.total > 0 ? (s.proceso / s.total) * 100 : 0;
@@ -250,7 +250,7 @@
             <div class="cartera-item">
               <div class="cartera-header">
                 <h4 class="cartera-title">
-                  <i class="ph-fill ph-briefcase" style="color: ${iconColor};"></i> 
+                  <i class="ph-fill ph-briefcase" style="color: ${iconColor};"></i>
                   ${c.nombre}
                 </h4>
                 <div class="cartera-badges">
@@ -260,7 +260,7 @@
                   ${s.enviado > 0 ? `<span class="c-badge warn"><i class="ph-bold ph-warning"></i> ${s.enviado} Sin Leer</span>` : ''}
                 </div>
               </div>
-              
+
               <div style="display:flex; justify-content:space-between; font-size: 11px; color: var(--text-muted); font-weight:600; text-transform:uppercase;">
                 <span>Eficiencia de Respuesta: ${pctAtendido.toFixed(1)}%</span>
                 ${rezago > 0 ? `<span style="color: var(--danger);"><i class="ph-bold ph-trend-down"></i> ${rezago} en Rezago</span>` : '<span style="color: var(--success);"><i class="ph-bold ph-trend-up"></i> Al corriente</span>'}

--- a/avisoprivacidad.html
+++ b/avisoprivacidad.html
@@ -9,14 +9,14 @@
     <style>
         :root {
             --bg-body: transparent; /* Transparente para heredar el fondo del iframe si es necesario, o el color base */
-            --bg-base: #1b2e45;
+            --bg-base: #004b33;
             --panel-base: 46, 79, 119;
-            --primary: #4da1a8; 
-            --primary-light: #7ad1d6;
+            --primary: #006341;
+            --primary-light: #8fd9b6;
             --success: #4ade80;
-            --text-main: #f0fdfa; 
+            --text-main: #f0fdfa;
             --text-muted: #bce9eb;
-            --ring: rgba(77, 161, 168, 0.35);
+            --ring: rgba(0, 99, 65, 0.35);
             --radius: 12px;
             --glass-bg: rgba(var(--panel-base), 0.25);
         }
@@ -107,7 +107,7 @@
             font-size: 15px;
         }
 
-        .accordion-header:hover { background: rgba(77, 161, 168, 0.1); }
+        .accordion-header:hover { background: rgba(0, 99, 65, 0.1); }
 
         .accordion-header span {
             font-size: 20px;
@@ -130,7 +130,7 @@
         }
 
         .accordion-content p { margin-bottom: 12px; }
-        
+
         .accordion-content ul {
             margin-left: 20px;
             margin-bottom: 12px;
@@ -277,7 +277,7 @@
         header.addEventListener('click', () => {
             const content = header.nextElementSibling;
             const span = header.querySelector('span');
-            
+
             // Cerrar otros acordeones si se desea (opcional)
             /* document.querySelectorAll('.accordion-content').forEach(c => {
                 if (c !== content) {
@@ -285,9 +285,9 @@
                     c.previousElementSibling.querySelector('span').style.transform = 'rotate(0deg)';
                 }
             }); */
-            
+
             content.classList.toggle('active');
-            
+
             // Animar el ícono de más/menos
             if(content.classList.contains('active')) {
                 span.textContent = '−';

--- a/biblioteca.html
+++ b/biblioteca.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Biblioteca — Plataforma Comunitaria CG</title>
-  
+
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css" />
@@ -12,12 +12,12 @@
   <style>
     :root {
       /* Paleta actualizada */
-      --bg: #1b2e45;
+      --bg: #004b33;
       --panel: #2e4f77;  /* Color solicitado */
       --txt: #f0fdfa;
       --muted: #bce9eb;
-      --primary: #4da1a8; /* Color solicitado */
-      --sky: #7ad1d6;
+      --primary: #006341; /* Color solicitado */
+      --sky: #8fd9b6;
     }
     * {
       box-sizing: border-box;
@@ -26,12 +26,12 @@
       font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
     body {
-      background: transparent; 
+      background: transparent;
       color: var(--txt);
       min-height: 100vh;
       padding: 24px; /* Añadido padding similar al buzón */
     }
-    
+
     .hide { display: none !important; }
 
     /* --- ESTADO DE CARGA --- */
@@ -40,7 +40,7 @@
 
     /* --- MURO DE ACCESO (AUTH WALL) --- */
     .auth-wall { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 70vh; text-align: center; background: rgba(46, 79, 119, 0.2); border: 1px dashed var(--sky); border-radius: 16px; padding: 32px; }
-    .auth-wall i { font-size: 64px; color: var(--sky); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(122,209,214,0.3)); }
+    .auth-wall i { font-size: 64px; color: var(--sky); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(143,217,182,0.3)); }
     .auth-wall h2 { margin: 0 0 12px 0; font-size: 24px; color: var(--txt); }
     .auth-wall p { margin: 0 0 24px 0; color: var(--muted); max-width: 400px; line-height: 1.5; font-size: 15px;}
 
@@ -50,7 +50,7 @@
 
     .card {
       background: var(--panel);
-      border: 1px solid rgba(77, 161, 168, .35);
+      border: 1px solid rgba(0, 99, 65, .35);
       border-radius: 16px;
       padding: 16px;
       margin-bottom: 12px;
@@ -77,17 +77,17 @@
     }
 
     input, textarea, select {
-      background: #1b2e45;
+      background: #004b33;
       color: #f0fdfa;
       padding: 8px 10px;
       border-radius: 10px;
-      border: 1px solid rgba(77, 161, 168, .4);
+      border: 1px solid rgba(0, 99, 65, .4);
       font-size: 14px;
     }
     input:focus, textarea:focus, select:focus {
       outline: none;
       border-color: var(--sky);
-      box-shadow: 0 0 0 3px rgba(77, 161, 168, 0.2);
+      box-shadow: 0 0 0 3px rgba(0, 99, 65, 0.2);
     }
     textarea {
       resize: vertical;
@@ -116,8 +116,8 @@
     }
 
     .subtle-btn {
-      background: rgba(77, 161, 168, .1);
-      border: 1px solid rgba(77, 161, 168, .28);
+      background: rgba(0, 99, 65, .1);
+      border: 1px solid rgba(0, 99, 65, .28);
       padding: 6px 10px;
       border-radius: 10px;
       cursor: pointer;
@@ -125,7 +125,7 @@
       font-size: 13px;
     }
     .subtle-btn:hover {
-      background: rgba(77, 161, 168, .25);
+      background: rgba(0, 99, 65, .25);
     }
 
     /* GRID DE LA LISTA */
@@ -138,12 +138,12 @@
 
     .lib-section-header {
       grid-column: 1 / -1;
-      border-top: 1px solid rgba(77, 161, 168, .28);
+      border-top: 1px solid rgba(0, 99, 65, .28);
       margin-top: 6px;
       padding-top: 8px;
       text-transform: uppercase;
       font-size: 12px;
-      color: #7ad1d6;
+      color: #8fd9b6;
       display: flex;
       gap: 6px;
       align-items: center;
@@ -152,10 +152,10 @@
 
     /* TARJETAS DE RECURSO */
     .resource-card {
-      background: radial-gradient(circle at top left, rgba(77, 161, 168, .15), transparent 55%), #233b5c;
+      background: radial-gradient(circle at top left, rgba(0, 99, 65, .15), transparent 55%), #233b5c;
       padding: 12px;
       border-radius: 14px;
-      border: 1px solid rgba(77, 161, 168, .3);
+      border: 1px solid rgba(0, 99, 65, .3);
       cursor: pointer;
       transition: transform .15s ease, box-shadow .15s ease, border-color .15s ease;
       box-shadow: 0 10px 25px rgba(0, 0, 0, .2);
@@ -163,7 +163,7 @@
     .resource-card:hover {
       transform: translateY(-2px);
       box-shadow: 0 14px 30px rgba(0, 0, 0, .35);
-      border-color: rgba(77, 161, 168, .65);
+      border-color: rgba(0, 99, 65, .65);
     }
 
     .resource-header {
@@ -197,8 +197,8 @@
 
     .pill {
       padding: 4px 8px;
-      background: rgba(77, 161, 168, .15);
-      border: 1px solid rgba(77, 161, 168, .35);
+      background: rgba(0, 99, 65, .15);
+      border: 1px solid rgba(0, 99, 65, .35);
       border-radius: 999px;
       font-size: 11px;
       color: #d1f5f7;
@@ -229,7 +229,7 @@
       border-radius: 16px; /* Ajustado al buzón */
       width: 100%;
       max-width: 640px;
-      border: 1px solid rgba(77, 161, 168, .5);
+      border: 1px solid rgba(0, 99, 65, .5);
       padding: 24px; /* Un poco más despacio interior */
       max-height: 90vh;
       display: flex;
@@ -387,7 +387,7 @@
     /* ========== CONFIG SUPABASE ========== */
     const SUPABASE_URL = "https://axsncdwshdvsysrpikwj.supabase.co";
     const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF4c25jZHdzaGR2c3lzcnBpa3dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyMjkwMjQsImV4cCI6MjA3NTgwNTAyNH0.oapcH219puVjaR2DcG7dX51uhwVn530L1hhz8ASv7qs";
-    
+
     // Objeto Supabase global
     let supabaseApp = null;
     let CURRENT_USER = null;
@@ -403,26 +403,26 @@
     async function initApp() {
       try {
         // Soporte para iframe o standalone (Igual que en buzón)
-        if (window.parent && window.parent.supabaseClient) { 
-          supabaseApp = window.parent.supabaseClient; 
-        } 
-        else if (window.supabase) { 
-          supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); 
-        } 
+        if (window.parent && window.parent.supabaseClient) {
+          supabaseApp = window.parent.supabaseClient;
+        }
+        else if (window.supabase) {
+          supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+        }
         else { throw new Error("Conexión no disponible."); }
 
         // Validar sesión activa
         const { data: { session }, error: sessionError } = await supabaseApp.auth.getSession();
-        
+
         // Ocultar spinner
         $("loading-state").classList.add("hide");
 
         if (sessionError) throw sessionError;
 
         // SI NO ESTÁ LOGUEADO -> Muestra el muro
-        if (!session) { 
-          $("auth-wall").classList.remove("hide"); 
-          return; 
+        if (!session) {
+          $("auth-wall").classList.remove("hide");
+          return;
         }
 
         // SI ESTÁ LOGUEADO -> Muestra contenido
@@ -673,7 +673,7 @@
 
       if (stats) stats.innerHTML = '<span style="color:#4ade80">✅ Recurso eliminado.</span>';
       if (fromModal) closeResourceModal();
-      
+
       LIBRARY_CACHE = LIBRARY_CACHE.filter(r => r.id !== item.id);
       renderLibrary();
     }
@@ -724,7 +724,7 @@
       // FORMATEADOR DE LINKS PARA DESCRIPCIÓN (Igual que Buzón)
       let contenidoSeguro = escapeHtml(item.description || "Sin descripción disponible.");
       contenidoSeguro = contenidoSeguro.replace(
-          /(https?:\/\/[^\s]+)/g, 
+          /(https?:\/\/[^\s]+)/g,
           '<div style="margin-top:10px;"><a href="$1" target="_blank" style="color:var(--sky);">Ver enlace extra</a></div>'
       );
       descEl.innerHTML = contenidoSeguro;

--- a/buzon.html
+++ b/buzon.html
@@ -8,21 +8,21 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css" />
-  
+
   <style>
     :root {
       --bg-body: transparent;
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; 
-      --primary-light: #7ad1d6;
+      --primary: #006341;
+      --primary-light: #8fd9b6;
       --success: #4ade80;
       --warning: #fbbf24;
       --danger: #ff7b7b;
-      --text-main: #f0fdfa; 
+      --text-main: #f0fdfa;
       --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
     }
-    
+
     body { margin: 0; padding: 24px; background-color: var(--bg-body); color: var(--text-main); font-family: 'Inter', sans-serif; box-sizing: border-box; }
     * { box-sizing: border-box; }
 
@@ -41,14 +41,14 @@
     .loading-state i { font-size: 48px; margin-bottom: 16px; }
 
     .auth-wall { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 70vh; text-align: center; background: rgba(var(--panel-base), 0.2); border: 1px dashed var(--primary-light); border-radius: 16px; padding: 32px; }
-    .auth-wall i { font-size: 64px; color: var(--primary-light); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(122,209,214,0.3)); }
+    .auth-wall i { font-size: 64px; color: var(--primary-light); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(143,217,182,0.3)); }
     .auth-wall h2 { margin: 0 0 12px 0; font-size: 24px; }
     .auth-wall p { margin: 0 0 24px 0; color: var(--text-muted); max-width: 400px; line-height: 1.5; }
 
     .btn { background: var(--primary); color: #0a141d; border: none; padding: 10px 20px; border-radius: 8px; font-weight: 700; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-size: 14px; transition: all 0.2s; text-decoration: none;}
-    .btn:hover { background: var(--primary-light); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(77, 161, 168, 0.3); }
+    .btn:hover { background: var(--primary-light); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0, 99, 65, 0.3); }
     .btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow: none; }
-    
+
     .btn.success { background: linear-gradient(135deg, #22c55e, #16a34a); color: white;}
     .btn.success:hover { box-shadow: 0 4px 15px rgba(34, 197, 94, 0.4); }
 
@@ -56,12 +56,12 @@
     .form-group { margin-bottom: 16px; }
     .form-group label { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 6px; font-weight: 600; }
     .form-control { width: 100%; padding: 12px; border-radius: 8px; border: 1px solid var(--ring); background: rgba(21, 35, 54, 0.8); color: var(--text-main); font-family: 'Inter', sans-serif; }
-    .form-control:focus { outline: none; border-color: var(--primary-light); box-shadow: 0 0 0 3px rgba(77, 161, 168, 0.2); }
+    .form-control:focus { outline: none; border-color: var(--primary-light); box-shadow: 0 0 0 3px rgba(0, 99, 65, 0.2); }
     textarea.form-control { min-height: 120px; resize: vertical; }
     input[type="file"].form-control { padding: 9px 12px; background: rgba(0,0,0,0.2); cursor: pointer; }
 
     .badge { padding: 4px 10px; border-radius: 999px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
-    .badge.enviado { background: rgba(77, 161, 168, 0.15); color: var(--primary-light); border: 1px solid var(--ring); }
+    .badge.enviado { background: rgba(0, 99, 65, 0.15); color: var(--primary-light); border: 1px solid var(--ring); }
     .badge.proceso { background: rgba(251, 191, 36, 0.15); color: var(--warning); border: 1px solid rgba(251, 191, 36, 0.3); }
     .badge.atendido { background: rgba(74, 222, 128, 0.15); color: var(--success); border: 1px solid rgba(74, 222, 128, 0.3); }
 
@@ -69,7 +69,7 @@
     .tabs { display: flex; gap: 10px; margin-bottom: 20px; border-bottom: 1px solid var(--ring); padding-bottom: 10px; overflow-x: auto; }
     .tab-btn { background: transparent; color: var(--text-muted); border: none; padding: 10px 20px; cursor: pointer; font-weight: 600; font-size: 14px; border-radius: 8px; transition: all 0.2s; white-space: nowrap; display: flex; align-items: center; gap: 6px; }
     .tab-btn i { font-size: 18px; }
-    .tab-btn.active { background: rgba(77, 161, 168, 0.2); color: var(--primary-light); border: 1px solid rgba(77, 161, 168, 0.4); }
+    .tab-btn.active { background: rgba(0, 99, 65, 0.2); color: var(--primary-light); border: 1px solid rgba(0, 99, 65, 0.4); }
     .tab-btn:hover:not(.active) { background: rgba(255,255,255,0.05); color: var(--text-main); }
 
     /* --- LISTA DE ESCRITOS --- */
@@ -84,7 +84,7 @@
     .modal-overlay.active { opacity: 1; pointer-events: auto; }
     .modal-content { background: linear-gradient(180deg, rgba(46,79,119,.95), rgba(27,46,69,.95)); border: 1px solid var(--ring); border-radius: 16px; padding: 24px; width: 100%; max-width: 600px; max-height: 90vh; overflow-y: auto; box-shadow: 0 10px 40px rgba(0,0,0,0.5); transform: translateY(20px); transition: transform 0.3s ease; }
     .modal-overlay.active .modal-content { transform: translateY(0); }
-    
+
     .respuesta-box { background: rgba(74, 222, 128, 0.05); border: 1px solid rgba(74, 222, 128, 0.3); border-radius: 12px; padding: 16px; margin-top: 16px; }
     .respuesta-box h4 { margin: 0 0 8px 0; color: var(--success); font-size: 14px; display: flex; align-items: center; gap: 6px;}
     .respuesta-box p { margin: 0; font-size: 14px; line-height: 1.5; white-space: pre-wrap; color: var(--text-main);}
@@ -119,7 +119,7 @@
 
     <div class="card" id="bandeja-section">
       <h3 id="bandeja-titulo"><i class="ph-duotone ph-tray"></i> Mi Bandeja</h3>
-      
+
       <div class="tabs" id="buzon-tabs">
         <button id="tab-1" class="tab-btn active" onclick="switchTab('tab1')"><i class="ph-bold ph-paper-plane-right"></i> Enviados</button>
         <button id="tab-2" class="tab-btn" onclick="switchTab('tab2')"><i class="ph-bold ph-download-simple"></i> Recibidos</button>
@@ -166,7 +166,7 @@
           <label>Escribir Respuesta Oficial (Opcional si adjuntas PDF)</label>
           <textarea id="m-respuesta-input" class="form-control" placeholder="Escribe aquí la respuesta que verá el persona usuaria..."></textarea>
         </div>
-        
+
         <div class="form-group">
           <label><i class="ph-bold ph-upload-simple"></i> Adjuntar PDF de Respuesta (Opcional)</label>
           <input type="file" id="m-respuesta-archivo" class="form-control" accept="application/pdf">
@@ -183,11 +183,11 @@
   <script>
     const SUPABASE_URL = "https://axsncdwshdvsysrpikwj.supabase.co";
     const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF4c25jZHdzaGR2c3lzcnBpa3dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyMjkwMjQsImV4cCI6MjA3NTgwNTAyNH0.oapcH219puVjaR2DcG7dX51uhwVn530L1hhz8ASv7qs";
-    
+
     let supabaseApp = null;
     let currentUser = null;
     let isAdmin = false;
-    let currentEscritos = []; 
+    let currentEscritos = [];
     let currentTab = 'tab1';
 
     // FUNCIÓN DE REDIRECCIÓN AL GENERADOR
@@ -201,8 +201,8 @@
 
     async function init() {
       try {
-        if (window.parent && window.parent.supabaseClient) { supabaseApp = window.parent.supabaseClient; } 
-        else if (window.supabase) { supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } 
+        if (window.parent && window.parent.supabaseClient) { supabaseApp = window.parent.supabaseClient; }
+        else if (window.supabase) { supabaseApp = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); }
         else { throw new Error("Conexión no disponible."); }
 
         const { data: { session }, error: sessionError } = await supabaseApp.auth.getSession();
@@ -210,16 +210,16 @@
 
         if (sessionError) throw sessionError;
         if (!session) { document.getElementById('auth-wall').classList.remove('hide'); return; }
-        
+
         currentUser = session.user;
         document.getElementById('main-content').classList.remove('hide');
 
         const { data: prof } = await supabaseApp.from('profiles').select('role, display_name').eq('user_id', currentUser.id).maybeSingle();
-        
+
         if (prof && prof.role === 'admin') {
           isAdmin = true;
           document.getElementById('bandeja-titulo').innerHTML = `<i class="ph-duotone ph-inbox"></i> Bandeja de Administración`;
-          
+
           // Cambiar el texto de las pestañas para los administradores
           document.getElementById('tab-1').innerHTML = `<i class="ph-bold ph-clock"></i> Pendientes`;
           document.getElementById('tab-2').innerHTML = `<i class="ph-bold ph-check-circle"></i> Atendidos`;
@@ -244,7 +244,7 @@
       document.getElementById('tab-1').classList.remove('active');
       document.getElementById('tab-2').classList.remove('active');
       document.getElementById(tabId).classList.add('active');
-      
+
       renderLista();
     }
 
@@ -306,7 +306,7 @@
 
         const displayAsunto = item.folio ? `[${item.folio}] ${item.asunto.replace(`[${item.folio}] `, '')}` : item.asunto;
 
-        let metaText = isAdmin 
+        let metaText = isAdmin
           ? `De: <strong>${item.profiles?.display_name || 'Compañero'}</strong> (Matrícula: ${item.profiles?.matricula || 'N/A'}) • Para: ${item.area_destino}`
           : `Destino: <strong>${item.area_destino}</strong>`;
 
@@ -333,10 +333,10 @@
 
       document.getElementById('m-badge').className = `badge ${badgeClass}`;
       document.getElementById('m-badge').textContent = item.estatus;
-      
+
       const displayAsunto = item.folio ? `[${item.folio}] ${item.asunto.replace(`[${item.folio}] `, '')}` : item.asunto;
       document.getElementById('m-asunto').textContent = displayAsunto;
-      
+
       let metaText = isAdmin ? `De: ${item.profiles?.display_name || 'Compañero'} • Fecha: ${new Date(item.fecha_envio).toLocaleString('es-MX')}` : `Enviado a: ${item.area_destino} • Fecha: ${new Date(item.fecha_envio).toLocaleString('es-MX')}`;
       document.getElementById('m-meta').textContent = metaText;
 
@@ -344,10 +344,10 @@
           .replace(/&/g, "&amp;")
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;");
-          
+
       contenidoSeguro = contenidoSeguro.replace(/📄 Ver Documento:\s*/g, '');
       contenidoSeguro = contenidoSeguro.replace(
-          /(https?:\/\/[^\s]+)/g, 
+          /(https?:\/\/[^\s]+)/g,
           '<div style="margin-top:16px;"><a href="$1" target="_blank" class="btn" style="color: #0a141d;"><i class="ph-bold ph-file-pdf"></i> Abrir Documento Original</a></div>'
       );
       document.getElementById('m-contenido').innerHTML = contenidoSeguro;
@@ -355,7 +355,7 @@
       const userReplyView = document.getElementById('m-respuesta-view');
       const adminReplyForm = document.getElementById('admin-reply-form');
       document.getElementById('reply-status').innerHTML = '';
-      document.getElementById('m-respuesta-archivo').value = ''; 
+      document.getElementById('m-respuesta-archivo').value = '';
 
       if (isAdmin) {
         adminReplyForm.classList.remove('hide');
@@ -368,7 +368,7 @@
         if (item.respuesta || item.archivo_respuesta || item.estatus === 'Atendido') {
           userReplyView.classList.remove('hide');
           document.getElementById('m-respuesta-text').textContent = item.respuesta || 'Se ha emitido un dictamen en el documento adjunto o se ha marcado como resuelto.';
-          
+
           if (item.archivo_respuesta) {
             document.getElementById('m-respuesta-archivo-btn').innerHTML = `<a href="${item.archivo_respuesta}" target="_blank" class="btn success" style="margin-top: 10px;"><i class="ph-bold ph-file-pdf"></i> Descargar Resolución Oficial</a>`;
           } else {
@@ -401,7 +401,7 @@
       const respuestaText = document.getElementById('m-respuesta-input').value;
       const fileInput = document.getElementById('m-respuesta-archivo');
       const file = fileInput.files[0];
-      
+
       const btn = document.getElementById('btnSaveReply');
       const statusDiv = document.getElementById('reply-status');
 
@@ -414,19 +414,19 @@
         if (file) {
           statusDiv.innerHTML = '<span style="color: var(--primary-light)"><i class="ph-bold ph-spinner ph-spin"></i> Subiendo PDF adjunto...</span>';
           const fileName = `respuestas/${Date.now()}_${id}.pdf`;
-          
+
           const { error: uploadError } = await supabaseApp.storage.from('documentos').upload(fileName, file);
           if (uploadError) throw uploadError;
-          
+
           const { data: { publicUrl } } = supabaseApp.storage.from('documentos').getPublicUrl(fileName);
           archivoUrl = publicUrl;
         }
 
         const updateData = { estatus: estatus };
-        
+
         if (respuestaText.trim() !== '') updateData.respuesta = respuestaText;
         if (archivoUrl) updateData.archivo_respuesta = archivoUrl;
-        
+
         if (respuestaText.trim() !== '' || archivoUrl) {
           const oldItem = currentEscritos.find(x => x.id === id);
           if (!oldItem.fecha_respuesta) updateData.fecha_respuesta = new Date().toISOString();
@@ -437,7 +437,7 @@
         if (error) throw error;
 
         statusDiv.innerHTML = '<span style="color: var(--success)">✅ Guardado exitosamente.</span>';
-        
+
         await loadDatos(); // Recargar datos frescos
         setTimeout(() => cerrarModal(), 1500);
 

--- a/calendario.html
+++ b/calendario.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <style>
     :root {
-      --bg-body: #1b2e45;
+      --bg-body: #004b33;
       --text-main: #f0fdfa;
       --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
-      --primary-light: #7ad1d6;
+      --ring: rgba(0, 99, 65, .35);
+      --primary-light: #8fd9b6;
     }
     body {
       margin: 0;

--- a/campaña-carlos-guerrero.html
+++ b/campaña-carlos-guerrero.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Perfil Principal - Plataforma Sección XX Michoacán</title>
-    
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
@@ -25,7 +25,7 @@
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        
+
         body {
             font-family: 'Inter', -apple-system, sans-serif;
             background-color: var(--fondo-oscuro);
@@ -79,7 +79,7 @@
         }
 
         main { position: relative; z-index: 1; }
-        
+
         section {
             min-height: 100vh;
             display: flex;
@@ -193,7 +193,7 @@
             transform: translateY(100px);
             transition: border-color 0.3s ease;
         }
-        
+
         .glass-card.is-scrolled {
             border-color: rgba(100, 255, 218, 0.3);
         }
@@ -252,7 +252,7 @@
             align-items: center;
             gap: 15px;
         }
-        
+
         .eje-icon {
             font-size: 3rem;
             color: var(--azul-cyan);
@@ -291,21 +291,21 @@
             border: 1px solid rgba(255,255,255,0.02);
             transition: all 0.3s ease;
         }
-        
+
         .propuestas-list li:hover {
             background: rgba(100, 255, 218, 0.05);
             border-color: rgba(100, 255, 218, 0.1);
             color: #fff;
         }
-        
+
         .check-icon {
             color: var(--azul-cyan);
             font-size: 1.3rem;
         }
 
         /* --- SECCIÓN PSD (EJE 6) ACTUALIZADA --- */
-        #psd-section { 
-            text-align: center; 
+        #psd-section {
+            text-align: center;
             min-height: 100vh;
             justify-content: center;
         }
@@ -324,10 +324,10 @@
         }
 
         .espacio-quiosco {
-            height: 350px; 
+            height: 350px;
             width: 100%;
         }
-        
+
         .red-persona usuariaes {
             font-size: 1.2rem;
             color: var(--azul-cyan);
@@ -398,7 +398,7 @@
                 padding: 12px;
             }
             .espacio-quiosco {
-                height: 250px; 
+                height: 250px;
             }
             .cta-button {
                 padding: 12px 30px;
@@ -565,12 +565,12 @@
 
         <section id="psd-section">
             <div class="glass-card scroll-reveal" style="pointer-events: auto;">
-                
+
                 <div style="margin-bottom: 1rem;">
                     <span class="red-persona usuariaes">Conexión Segura</span>
                     <span class="eje-numero" style="font-size: 1.5rem; display: block;">Eje Final 06</span>
                     <h2 style="font-size: clamp(2.5rem, 8vw, 4.5rem); justify-content: center; border: none; color: white; line-height: 1.1; margin-bottom: 0;">INNOVACIÓN DIGITAL</h2>
-                    
+
                     <button class="btn-audio-eje" data-audio="audio-eje6" style="margin-top: 1rem;">
                         <i class="ph-fill ph-speaker-high"></i> Escuchar Propuesta
                     </button>
@@ -594,12 +594,12 @@
             <h2>DE TRABAJADOR<br>A TRABAJADOR</h2>
             <p class="frase-fuerza" style="display: inline-block; border: none; padding-left: 0; text-transform: uppercase;">"estamos contigo."</p>
             <p style="color: var(--azul-cyan); font-size: 2rem; margin: 30px 0; font-weight: 900; filter: drop-shadow(0 0 10px rgba(100, 255, 218, 0.4));">VOTA AZUL ESTE 6 DE ABRIL</p>
-            
+
             <a href="https://chat.whatsapp.com/G5gGUZxnubW0Eqb7NnxJ1d" class="cta-button whatsapp-button" target="_blank" rel="noopener noreferrer">
                 <i class="ph-bold ph-whatsapp-logo" style="font-size: 1.5rem;"></i>
                 ÚNETE AL EQUIPO
             </a>
-            
+
             <span style="font-size: 1rem; color: var(--texto-gris); text-transform: uppercase; letter-spacing: 0.2em; margin-top: 15px; display: block;">Sección XX, Michoacán 2026-2032</span>
         </footer>
     </main>
@@ -631,7 +631,7 @@
                     // Detener todos los audios
                     todosLosAudios.forEach(aud => {
                         aud.pause();
-                        aud.currentTime = 0; 
+                        aud.currentTime = 0;
                     });
 
                     // Restaurar el texto y diseño original de todos los botones
@@ -668,7 +668,7 @@
             scene.fog = new THREE.FogExp2(0x02060d, 0.002);
 
             const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-            camera.position.z = 40; 
+            camera.position.z = 40;
 
             const renderer = new THREE.WebGLRenderer({ canvas: canvas, alpha: true, antialias: true });
             renderer.setSize(window.innerWidth, window.innerHeight);
@@ -676,18 +676,18 @@
 
             // --- 4. PARTÍCULAS DE FONDO ---
             const particlesGeometry = new THREE.BufferGeometry();
-            const particlesCount = 2500; 
+            const particlesCount = 2500;
             const posArray = new Float32Array(particlesCount * 3);
 
             for(let i = 0; i < particlesCount * 3; i++) {
-                posArray[i] = (Math.random() - 0.5) * 200; 
+                posArray[i] = (Math.random() - 0.5) * 200;
             }
 
             particlesGeometry.setAttribute('position', new THREE.BufferAttribute(posArray, 3));
-            
+
             const particlesMaterial = new THREE.PointsMaterial({
                 size: 0.2,
-                color: 0x1d4e89, 
+                color: 0x1d4e89,
                 transparent: true,
                 opacity: 0.6,
                 blending: THREE.AdditiveBlending,
@@ -699,28 +699,28 @@
 
             // --- 5. MODELO 3D PSD ---
             const kioskGroup = new THREE.Group();
-            
+
             const outerGeo = new THREE.CylinderGeometry(5, 5, 12, 6);
-            const outerMat = new THREE.MeshBasicMaterial({ 
-                color: 0x64ffda, 
-                wireframe: true, 
-                transparent: true, 
-                opacity: 0 
+            const outerMat = new THREE.MeshBasicMaterial({
+                color: 0x64ffda,
+                wireframe: true,
+                transparent: true,
+                opacity: 0
             });
             const outerMesh = new THREE.Mesh(outerGeo, outerMat);
-            
+
             const coreGeo = new THREE.SphereGeometry(2, 32, 32);
-            const coreMat = new THREE.MeshBasicMaterial({ 
-                color: 0xffffff, 
-                transparent: true, 
-                opacity: 0 
+            const coreMat = new THREE.MeshBasicMaterial({
+                color: 0xffffff,
+                transparent: true,
+                opacity: 0
             });
             const coreMesh = new THREE.Mesh(coreGeo, coreMat);
 
             kioskGroup.add(outerMesh);
             kioskGroup.add(coreMesh);
-            
-            kioskGroup.position.set(0, -30, -20); 
+
+            kioskGroup.position.set(0, -30, -20);
             scene.add(kioskGroup);
 
             // --- 6. INTERACTIVIDAD DE RATÓN ---
@@ -742,18 +742,18 @@
 
                 targetX = mouseX * 0.0003;
                 targetY = mouseY * 0.0003;
-                
+
                 particlesMesh.rotation.y += 0.02 * (targetX - particlesMesh.rotation.y);
                 particlesMesh.rotation.x += 0.02 * (targetY - particlesMesh.rotation.x);
-                
+
                 particlesMesh.position.y = (elapsedTime * 1.5) % 100;
                 particlesMesh.position.x = Math.sin(elapsedTime * 0.2) * 5;
 
                 kioskGroup.rotation.y = elapsedTime * 0.3;
                 outerMesh.rotation.x = elapsedTime * 0.1;
                 coreMesh.scale.set(
-                    1 + Math.sin(elapsedTime * 3) * 0.08, 
-                    1 + Math.sin(elapsedTime * 3) * 0.08, 
+                    1 + Math.sin(elapsedTime * 3) * 0.08,
+                    1 + Math.sin(elapsedTime * 3) * 0.08,
                     1 + Math.sin(elapsedTime * 3) * 0.08
                 );
 
@@ -769,14 +769,14 @@
                 camera.aspect = window.innerWidth / window.innerHeight;
                 camera.updateProjectionMatrix();
                 renderer.setSize(window.innerWidth, window.innerHeight);
-                
+
                 if (window.innerWidth < 768) {
-                    kioskGroup.scale.set(0.5, 0.5, 0.5); 
+                    kioskGroup.scale.set(0.5, 0.5, 0.5);
                 } else {
-                    kioskGroup.scale.set(1, 1, 1); 
+                    kioskGroup.scale.set(1, 1, 1);
                 }
-                
-                ScrollTrigger.refresh(); 
+
+                ScrollTrigger.refresh();
             };
 
             window.addEventListener('resize', handleResize);
@@ -790,7 +790,7 @@
                 gsap.to(card, {
                     scrollTrigger: {
                         trigger: card,
-                        start: "top 85%", 
+                        start: "top 85%",
                         end: "bottom 15%",
                         toggleActions: "play reverse play reverse",
                         onEnter: () => card.classList.add('is-scrolled'),
@@ -800,7 +800,7 @@
                     y: 0,
                     duration: 1.2,
                     ease: "power3.out",
-                    delay: index * 0.1 
+                    delay: index * 0.1
                 });
             });
 
@@ -810,7 +810,7 @@
                     trigger: "#psd-section",
                     start: "top 80%",
                     end: "center center",
-                    scrub: 1 
+                    scrub: 1
                 },
                 y: 0,
                 z: -5,
@@ -836,7 +836,7 @@
                 },
                 opacity: 1
             });
-            
+
             ScrollTrigger.create({
                 trigger: "#hero",
                 start: "top top",
@@ -848,21 +848,21 @@
                     trigger: "#psd-section",
                     start: "top center",
                     end: "bottom bottom",
-                    scrub: 0.5 
+                    scrub: 0.5
                 },
-                r: 100/255, g: 255/255, b: 218/255 
+                r: 100/255, g: 255/255, b: 218/255
             });
 
             gsap.to(particlesMesh.position, {
                 scrollTrigger: {
-                    trigger: "#eje2", 
+                    trigger: "#eje2",
                     start: "top center",
                     end: "bottom bottom",
                     scrub: 2
                 },
-                y: 200 
+                y: 200
             });
-            
+
             setTimeout(() => { ScrollTrigger.refresh(); }, 500);
         });
     </script>

--- a/celular.html
+++ b/celular.html
@@ -12,16 +12,16 @@
 
   <link href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.1/cropper.min.css" rel="stylesheet">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.1/cropper.min.js"></script>
-  
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
 
   <style>
     :root {
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; --primary-light: #7ad1d6;
+      --primary: #006341; --primary-light: #8fd9b6;
       --text-main: #f0fdfa;
       --text-muted: rgba(240, 253, 250, 0.65);
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
       --radius: 12px;
     }
 
@@ -69,7 +69,7 @@
       background: #000;
       justify-content: center; align-items: center;
     }
-    
+
     #preview-img { max-width: 100%; max-height: 100%; display: block; object-fit: contain; }
 
     /* CONTENEDOR PARA SUBIR PDF */
@@ -144,7 +144,7 @@
     <i class="ph-duotone ph-file-pdf" style="font-size: 80px; color: var(--primary-light); margin-bottom: 20px;"></i>
     <h3 style="margin: 0 0 10px 0;">Sube tu archivo PDF</h3>
     <p style="color: var(--text-muted); margin-bottom: 30px;">Recuerda que el documento no debe superar las 5 hojas permitidas.</p>
-    
+
     <input type="file" id="pdf-file-input" accept="application/pdf" style="display: none;">
     <button class="btn" style="width: 80%;" onclick="document.getElementById('pdf-file-input').click()">
       <i class="ph-bold ph-upload-simple"></i> Seleccionar PDF
@@ -173,7 +173,7 @@
 
     const urlParams = new URLSearchParams(window.location.search);
     const idSesion = urlParams.get('sesion') || 'TEST';
-    const tipoScan = urlParams.get('tipo') || 'identificacion'; 
+    const tipoScan = urlParams.get('tipo') || 'identificacion';
 
     const video = document.getElementById('video');
     const cropArea = document.getElementById('crop-area');
@@ -193,7 +193,7 @@
     let imagenReverso = null;
     let streamActual = null;
     let scanicScanner = null;
-    let autoscanDataUrl = null; 
+    let autoscanDataUrl = null;
 
     function setOverlay(show, titleText = "Procesando…", descText = "Por favor espera.") {
       overlayTitle.innerText = titleText;
@@ -229,7 +229,7 @@
       document.getElementById('camera-section').style.display = 'none';
       document.getElementById('controls-section').style.display = 'none';
       document.getElementById('pdf-upload-container').style.display = 'flex';
-      
+
       titulo.innerText = "Enviar Documento PDF";
       subtitulo.innerText = "Selecciona un archivo de tu dispositivo";
 
@@ -255,7 +255,7 @@
             pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
 
             const pdf = await pdfjsLib.getDocument(typedarray).promise;
-            
+
             // Validación de las 5 hojas
             if (pdf.numPages > 5) {
               setOverlay(false);
@@ -354,7 +354,7 @@
       previewImg.src = dataUrl;
       video.style.display = 'none';
       guideline.style.display = 'none';
-      
+
       btnCapturar.classList.add('hide');
       grupoConfirmar.classList.remove('hide');
 
@@ -407,9 +407,9 @@
         if (result && result.success && result.output) {
           return result.output.toDataURL('image/jpeg', 0.95);
         }
-        return null; 
+        return null;
       } catch (e) {
-        return null; 
+        return null;
       }
     }
 
@@ -440,7 +440,7 @@
     function reintentarFoto() {
       autoscanDataUrl = null;
       if (cropper) { cropper.destroy(); cropper = null; }
-      
+
       cropArea.style.display = 'none';
       video.style.display = 'block';
       guideline.style.display = 'flex';
@@ -509,7 +509,7 @@
 
       const canvasFinal = document.createElement('canvas');
       const ctxFinal = canvasFinal.getContext('2d');
-      canvasFinal.width = 1275; 
+      canvasFinal.width = 1275;
       canvasFinal.height = 1650;
 
       ctxFinal.fillStyle = "white";

--- a/comite.html
+++ b/comite.html
@@ -7,23 +7,23 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <style>
     :root {
-      --bg: #1b2e45;
+      --bg: #004b33;
       --panel: #2e4f77;
       --panel2: #395f8d;
       --txt: #f0fdfa;
       --muted: #bce9eb;
-      --primary: #4da1a8;
+      --primary: #006341;
       --primary-hover: #3b8289;
       --danger: #d9534f;
       --danger-hover: #c9302c;
       --ok: #45d39f;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
       --shadow: 0 10px 25px rgba(0, 0, 0, .2);
       --shadow-hover: 0 15px 35px rgba(0, 0, 0, .4);
     }
 
     * { box-sizing: border-box; }
-    
+
     body {
       margin: 0;
       font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
@@ -96,7 +96,7 @@
     button:active { transform: scale(0.95); }
 
     .btn-primary { background: var(--primary); color: white; }
-    .btn-primary:hover { background: var(--primary-hover); box-shadow: 0 4px 12px rgba(77, 161, 168, 0.4); }
+    .btn-primary:hover { background: var(--primary-hover); box-shadow: 0 4px 12px rgba(0, 99, 65, 0.4); }
 
     .btn-danger { background: var(--danger); color: white; }
     .btn-danger:hover { background: var(--danger-hover); box-shadow: 0 4px 12px rgba(217, 83, 79, 0.4); }
@@ -183,7 +183,7 @@
       display: block;
       background: #17304f;
       transition: transform 0.3s ease;
-      
+
       /* --- PROTECCIÓN DE IMAGEN --- */
       pointer-events: none; /* Hace que la imagen sea "invisible" al clic del mouse */
       user-select: none; /* Evita que la seleccionen como texto */
@@ -224,17 +224,17 @@
       text-align: center;
       color: var(--primary);
     }
-    
+
     .cargo-badge {
       display: inline-block;
-      background: rgba(77, 161, 168, 0.2);
+      background: rgba(0, 99, 65, 0.2);
       color: #e0f2f1;
       padding: 4px 10px;
       border-radius: 6px;
       font-weight: 600;
       font-size: 0.85rem;
       margin-bottom: 10px;
-      border: 1px solid rgba(77, 161, 168, 0.4);
+      border: 1px solid rgba(0, 99, 65, 0.4);
       align-self: flex-start;
     }
 
@@ -404,7 +404,7 @@
         flex-direction: column;
         gap: 8px;
       }
-      
+
       .main-category-title {
         font-size: 1.4rem;
         margin-bottom: 16px;
@@ -414,7 +414,7 @@
       .desc-text {
         display: none; /* Oculto por defecto en celular */
       }
-      
+
       .desc-text.show {
         display: block; /* Se muestra al hacer clic */
         animation: fadeInUp 0.3s ease;
@@ -433,7 +433,7 @@
     <div class="topbar">
       <div class="title-group">
         <button id="btnBack" class="btn-muted"><i class="fa-solid fa-arrow-left"></i> Volver</button>
-        
+
         <div class="title">
           <i class="fa-solid fa-sitemap"></i> Estructura del Comité
           <span id="adminBadge" class="admin-badge hidden"><i class="fa-solid fa-shield-halved"></i> Admin</span>
@@ -457,7 +457,7 @@
         <input id="area" type="text" placeholder="Cargo en la cartera (Ej. Titular, Auxiliar)" />
         <input id="categoria" type="text" placeholder="Categoría Laboral (Ej. Médico, Administrativo)" />
         <input id="unidad" type="text" placeholder="Unidad de adscripción" />
-        
+
         <input id="foto" type="url" placeholder="Pega aquí el enlace de Google Drive (Ej. https://drive.google.com/file/...)" style="grid-column: 1 / -1;" />
 
         <textarea id="descripcion" placeholder="Descripción o reseña del integrante"></textarea>
@@ -577,7 +577,7 @@
         setDebug('Sin registros en la base de datos.', 'ok', 'fa-check');
       } else {
         setDebug('Estructura cargada correctamente.', 'ok', 'fa-cloud-arrow-down');
-        setTimeout(() => debugBox.classList.add('hidden'), 3000); 
+        setTimeout(() => debugBox.classList.add('hidden'), 3000);
       }
       renderComite(data || []);
     }
@@ -613,14 +613,14 @@
       let animDelay = 0;
 
       for (const [nombreBloque, miembros] of Object.entries(grupos)) {
-        if (miembros.length === 0) continue; 
+        if (miembros.length === 0) continue;
 
         html += `
           <div class="main-category-group" style="animation-delay: ${animDelay}s">
             <h1 class="main-category-title"><i class="fa-solid fa-layer-group"></i> ${escapeHtml(nombreBloque)}</h1>
             <div class="grid">
         `;
-        
+
         animDelay += 0.1;
 
         html += miembros.map(item => {
@@ -636,7 +636,7 @@
               <div class="meta"><i class="fa-solid fa-briefcase"></i> <span><strong>Cartera:</strong> ${escapeHtml(item.cartera || '-')}</span></div>
               <div class="meta"><i class="fa-solid fa-user-tag"></i> <span><strong>Categoría:</strong> ${escapeHtml(item.categoria || '-')}</span></div>
               <div class="meta"><i class="fa-solid fa-location-dot"></i> <span><strong>Unidad:</strong> ${escapeHtml(item.unidad || '-')}</span></div>
-              
+
               ${(item.descripcion || item.desc) ? `
                 <div class="desc-container">
                   <div class="desc-text">${escapeHtml(item.descripcion || item.desc)}</div>
@@ -690,7 +690,7 @@
       unidad.value = item.unidad || '';
       foto.value = item.foto || '';
       descripcion.value = item.descripcion || item.desc || '';
-      
+
       formMessage.innerHTML = `<i class="fa-solid fa-pen"></i> Editando registro activo`;
       adminPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -704,7 +704,7 @@
 
     memberForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      
+
       btnSubmitForm.disabled = true;
       formMessage.innerHTML = `<i class="fa-solid fa-spinner fa-spin"></i> Guardando datos...`;
 

--- a/consultalugar.html
+++ b/consultalugar.html
@@ -8,20 +8,20 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css" />
-  
+
   <style>
     :root {
       --bg-body: transparent;
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; 
-      --primary-light: #7ad1d6;
+      --primary: #006341;
+      --primary-light: #8fd9b6;
       --success: #4ade80;
       --danger: #ff7b7b;
-      --text-main: #f0fdfa; 
+      --text-main: #f0fdfa;
       --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
     }
-    
+
     body { margin: 0; padding: 24px; background-color: var(--bg-body); color: var(--text-main); font-family: 'Inter', sans-serif; box-sizing: border-box; }
     * { box-sizing: border-box; }
 
@@ -36,22 +36,22 @@
     .loading-state i { font-size: 48px; margin-bottom: 16px; }
 
     .auth-wall { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 70vh; text-align: center; background: rgba(var(--panel-base), 0.2); border: 1px dashed var(--primary-light); border-radius: 16px; padding: 32px; }
-    .auth-wall i { font-size: 64px; color: var(--primary-light); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(122,209,214,0.3)); }
+    .auth-wall i { font-size: 64px; color: var(--primary-light); margin-bottom: 16px; filter: drop-shadow(0 0 10px rgba(143,217,182,0.3)); }
     .auth-wall h2 { margin: 0 0 12px 0; font-size: 24px; }
     .auth-wall p { margin: 0 0 24px 0; color: var(--text-muted); max-width: 400px; line-height: 1.5; }
 
     .blur-container { background: rgba(0, 0, 0, 0.25); border-radius: 12px; position: relative; overflow: hidden; border: 1px solid var(--ring); min-height: 150px;}
     .blur-content { filter: blur(8px); opacity: 0.4; pointer-events: none; user-select: none; transition: filter 0.3s;}
     .blur-content.unlocked { filter: blur(0); opacity: 1; pointer-events: auto; user-select: auto; }
-    
+
     .promo-overlay { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; background: rgba(27, 46, 69, 0.8); text-align: center; padding: 24px; z-index: 10; }
     .promo-overlay i { font-size: 42px; color: var(--primary-light); margin-bottom: 12px; }
     .promo-overlay p { margin: 0 0 8px 0; font-size: 16px; font-weight: 500; line-height: 1.4; color: var(--text-main); }
     .promo-overlay .highlight { color: var(--primary-light); font-size: 20px; font-weight: 800; text-transform: uppercase; letter-spacing: 0.5px; display: block; margin-top: 4px;}
-    
+
     .tramite-item { padding: 16px; border-bottom: 1px solid rgba(255,255,255,0.05); }
     .tramite-item:last-child { border-bottom: none; }
-    .tramite-rank { font-size: 38px; font-weight: 800; color: var(--primary-light); background: rgba(77, 161, 168, 0.15); padding: 12px 24px; border-radius: 12px; text-align: center; line-height: 1;}
+    .tramite-rank { font-size: 38px; font-weight: 800; color: var(--primary-light); background: rgba(0, 99, 65, 0.15); padding: 12px 24px; border-radius: 12px; text-align: center; line-height: 1;}
     .tramite-rank span { display: block; font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--text-muted); letter-spacing: 1px; margin-top: 4px; }
 
     .pdf-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
@@ -70,7 +70,7 @@
     .form-group label { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 6px; }
     .form-control { width: 100%; padding: 10px 12px; border-radius: 8px; border: 1px solid var(--ring); background: rgba(21, 35, 54, 0.8); color: var(--text-main); font-family: 'Inter', sans-serif; }
     .form-control:focus { outline: none; border-color: var(--primary-light); }
-    
+
     .btn { background: var(--primary); color: var(--bg-body); border: none; padding: 12px 24px; border-radius: 8px; font-weight: 700; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-size: 14px; transition: all 0.2s; }
     .btn:hover { background: var(--primary-light); transform: translateY(-2px); }
     .btn:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
@@ -99,7 +99,7 @@
 
     <div class="card" style="padding: 0; overflow: hidden; border: none; background: transparent;">
       <div class="blur-container" id="user-data-container">
-        
+
         <div class="blur-content" id="real-data-render">
           <div class="tramite-item" style="display: flex; flex-direction: column; gap: 16px; background: rgba(var(--panel-base), 0.3);">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -167,7 +167,7 @@
   <script>
     const SUPABASE_URL = "https://axsncdwshdvsysrpikwj.supabase.co";
     const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF4c25jZHdzaGR2c3lzcnBpa3dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyMjkwMjQsImV4cCI6MjA3NTgwNTAyNH0.oapcH219puVjaR2DcG7dX51uhwVn530L1hhz8ASv7qs";
-    
+
     let supabaseApp = null;
     let isAdmin = false;
     let currentUserMatricula = null;
@@ -189,21 +189,21 @@
 
         if (result?.error) throw result.error;
         if (!session) { document.getElementById('auth-wall').classList.remove('hide'); return; }
-        
+
         document.getElementById('main-content').classList.remove('hide');
 
         const { data: prof } = await supabaseApp.from('profiles').select('role, matricula').eq('user_id', session.user.id).maybeSingle();
-        
+
         if (prof) {
           currentUserMatricula = prof.matricula;
           if (prof.role === 'admin') {
             isAdmin = true;
             document.getElementById('admin-section').classList.remove('hide');
             document.getElementById('pdf-section').classList.remove('hide');
-            
+
             document.getElementById('promo-wall').style.display = 'none';
             document.getElementById('real-data-render').classList.add('unlocked');
-            
+
             loadPDFs();
           }
         }
@@ -222,7 +222,7 @@
     // --- RENDERIZAR DATOS DEL USUARIO ---
     async function loadUserRank() {
       const container = document.getElementById('real-data-render');
-      
+
       if (!currentUserMatricula) {
         container.innerHTML = `<div style="padding: 20px; text-align:center; color: var(--danger);">No tienes una matrícula registrada en tu perfil. Modifícalo para poder consultar.</div>`;
         return;
@@ -261,7 +261,7 @@
                 <span style="color: var(--text-muted); font-size: 13px;">Arriba de ti:</span>
               </div>
               <div style="font-weight: 700; color: var(--text-main); margin-bottom: 16px; padding-left: 28px;">${t.nombre_arriba}</div>
-              
+
               <div style="border-top: 1px dashed rgba(255,255,255,0.1); margin-bottom: 16px;"></div>
 
               <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 4px;">
@@ -282,25 +282,25 @@
       let rawRecords = [];
       const tramiteTitulo = document.getElementById('docTitle').value;
       const periodoInput = document.getElementById('docPeriodo').value;
-      
+
       const nameRegex = /[A-ZÑ ]+\/[A-ZÑ ]+\/[A-ZÑ ]+/;
-      const matRegex = /\b\d{8}\b/; 
-      
+      const matRegex = /\b\d{8}\b/;
+
       for (let i = 1; i <= pdf.numPages; i++) {
         const page = await pdf.getPage(i);
         const content = await page.getTextContent();
         let currentName = null;
-        
+
         for (let item of content.items) {
-          let text = item.str.trim().replace(/,/g, ' '); 
+          let text = item.str.trim().replace(/,/g, ' ');
           let foundName = text.match(nameRegex);
           let foundMat = text.match(matRegex);
 
           if (foundName) currentName = foundName[0].trim();
-          
+
           if (foundMat && currentName) {
             rawRecords.push({ nombre: currentName, matricula: foundMat[0] });
-            currentName = null; 
+            currentName = null;
           }
         }
       }
@@ -342,7 +342,7 @@
 
       try {
         const finalRecords = await extractDataFromPDF(fileInput);
-        
+
         if (finalRecords.length === 0) {
           throw new Error("No se encontraron matrículas o nombres legibles en este PDF.");
         }
@@ -361,8 +361,8 @@
 
         statusDiv.innerHTML = `<span style="color: var(--success)">✅ ¡Éxito! Se procesaron y ocultaron ${finalRecords.length} lugares en la plataforma.</span>`;
         document.getElementById('upload-form').reset();
-        
-        loadPDFs(); 
+
+        loadPDFs();
         loadUserRank();
 
       } catch (err) {
@@ -392,10 +392,10 @@
     }
 
     async function deletePDF(id, event) {
-      event.preventDefault(); 
+      event.preventDefault();
       if (!isAdmin || !confirm('¿Eliminar este PDF del registro? (Esto no borra los lugares en BD, solo el archivo)')) return;
       await supabaseApp.from('listados_pdf').delete().eq('id', id);
-      loadPDFs(); 
+      loadPDFs();
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/denuncias.html
+++ b/denuncias.html
@@ -15,9 +15,9 @@
     --bg-gradient: radial-gradient(circle at top center, #1e293b, #0f172a);
     --panel-bg: rgba(30, 41, 59, 0.7);
     --panel-border: rgba(148, 163, 184, 0.1);
-    --primary: #38bdf8;
-    --primary-hover: #0ea5e9;
-    --accent: #7dd3fc;
+    --primary: #006341;
+    --primary-hover: #007a50;
+    --accent: #8fd9b6;
     --success: #4ade80;
     --warning: #fbbf24;
     --danger: #ef4444;
@@ -30,13 +30,13 @@
 
   * { box-sizing: border-box; transition: all 0.2s ease; }
   html, body { height: 100%; margin: 0; background: var(--bg-dark); background-image: var(--bg-gradient); color: var(--text-main); font-family: 'Inter', sans-serif; }
-  
+
   .wrap { max-width: 1000px; width: 95%; margin: 0 auto; padding: 30px 15px; }
-  
+
   h1 { font-size: 24px; text-align: center; background: linear-gradient(90deg, #fff, var(--primary)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; margin-bottom: 24px; }
 
   .card { background: var(--panel-bg); border: 1px solid var(--panel-border); border-radius: 20px; padding: 30px; backdrop-filter: blur(12px); box-shadow: 0 20px 40px rgba(0,0,0,0.3); min-height: 400px; }
-  
+
   /* GRID DE DATOS REVISADO PARA RESPONSIVE */
   .info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 30px; padding: 20px; background: rgba(255,255,255,0.03); border-radius: 12px; border: 1px solid var(--panel-border); }
   .grid-full { grid-column: 1 / -1; }
@@ -48,7 +48,7 @@
   label { display: block; font-size: 12px; font-weight: 700; color: var(--accent); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
   input, select, textarea { width: 100%; padding: 14px; border-radius: 10px; border: 1px solid var(--input-border); background: var(--input-bg); color: #fff; font-size: 15px; font-family: 'Inter', sans-serif; }
   textarea { min-height: 120px; resize: vertical; }
-  
+
   input[readonly] { background: rgba(15, 23, 42, 0.3); border-color: transparent; color: var(--text-muted); cursor: not-allowed; font-weight: 600; }
 
   /* AVANZADO */
@@ -63,7 +63,7 @@
   .btn.success { background: linear-gradient(135deg, #22c55e, #16a34a); color: #fff; }
   .btn.danger { background: linear-gradient(135deg, #ef4444, #dc2626); color: #fff; }
   .btn.outline { background: transparent; border: 1px solid var(--panel-border); color: var(--text-main); }
-  .btn.outline-accent { background: rgba(56, 189, 248, 0.1); border: 1px solid var(--primary); color: var(--primary); font-size: 13px; padding: 10px 16px; border-radius: 8px; width: auto; display: inline-flex; }
+  .btn.outline-accent { background: rgba(0, 99, 65, 0.1); border: 1px solid var(--primary); color: var(--primary); font-size: 13px; padding: 10px 16px; border-radius: 8px; width: auto; display: inline-flex; }
   .btn.outline-accent:hover { background: var(--primary); color: #0f172a; }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
@@ -78,7 +78,7 @@
   .modal.show { display: flex; }
   .modal-card { background: #1e293b; border-radius: 20px; width: 100%; max-width: 1000px; padding: 30px; display: flex; flex-direction: column; max-height: 95vh;}
   .modal-b { flex: 1; overflow: auto; display: flex; justify-content: center; background: #334155; border-radius: 12px; padding: 20px; margin: 15px 0;}
-  
+
   /* HOJA TAMAÑO CARTA DINÁMICA (CORREGIDA) */
   .page.carta { width: 816px; min-height: 1056px; height: auto; background: #fff; color: #111; box-shadow: 0 10px 40px rgba(0,0,0,0.5); flex-shrink: 0; transform-origin: top center; }
   .sheet { padding: 50px 64px; font-family: "Times New Roman", Times, serif; font-size: 12pt; line-height: 1.5; min-height: 1056px; display: flex; flex-direction: column; color: #000; }
@@ -91,7 +91,7 @@
 
   /* ALERTAS Y GUÍA */
   .lock-alert { background: rgba(251, 191, 36, 0.15); border: 1px solid rgba(251, 191, 36, 0.4); color: var(--warning); padding: 16px; border-radius: 12px; font-size: 14px; text-align: center; margin-bottom: 20px; line-height: 1.5; }
-  
+
   .guia-categoria { font-size: 16px; color: var(--primary); margin: 20px 0 10px 0; padding-bottom: 5px; border-bottom: 1px solid var(--panel-border); font-weight: bold; text-transform: uppercase;}
   .guia-item { background: rgba(255,255,255,0.03); border: 1px solid var(--panel-border); padding: 15px; border-radius: 10px; margin-bottom: 10px; }
   .guia-item h4 { color: var(--accent); margin: 0 0 5px 0; font-size: 15px; }
@@ -119,28 +119,28 @@
   @media print {
     /* 1. Oculta absolutamente todo en la página por defecto */
     body > * { display: none !important; }
-    
+
     /* 2. Muestra ÚNICAMENTE el modal donde está el documento */
     #modalFirma { display: block !important; position: static !important; background: transparent !important; padding: 0 !important; }
-    
+
     /* 3. Limpia los contenedores oscuros para que no salgan en la hoja */
     .modal-card { background: transparent !important; box-shadow: none !important; padding: 0 !important; width: 100% !important; max-width: 100% !important; margin: 0 !important; border: none !important; }
-    
+
     /* 4. Oculta la cabecera (botones de Imprimir/Descargar) y las alertas */
     #modalFirma .modal-card > div:not(.modal-b) { display: none !important; }
-    
+
     /* 5. Asegura que el área del documento fluya libremente */
     .modal-b { display: block !important; padding: 0 !important; background: transparent !important; overflow: visible !important; margin: 0 !important; border: none !important; }
-    
+
     /* 6. Ajusta la hoja blanca para que ocupe todo el papel sin la escala de la pantalla */
     #page.carta { width: 100% !important; height: auto !important; transform: none !important; box-shadow: none !important; margin: 0 !important; }
-    
+
     /* 7. Márgenes reales de impresión */
     .sheet { padding: 1.5cm 2cm !important; height: auto !important; }
-    
+
     /* 8. Fuerza la firma y despedida al final del texto, evitando cortes raros */
     .sheet .pie { position: relative !important; bottom: auto !important; left: 0 !important; right: 0 !important; width: 100% !important; margin-top: 50px !important; text-align: center !important; page-break-inside: avoid; }
-    
+
     @page { size: letter; margin: 0; }
   }
 </style>
@@ -155,7 +155,7 @@
     <h1>Generador de Escritos PSD</h1>
 
     <div class="card">
-      
+
       <div id="loader-inicial">
         <i class="ph-bold ph-spinner anim-spin" style="font-size: 40px; margin-bottom: 10px;"></i>
         <p>Verificando credenciales...</p>
@@ -173,7 +173,7 @@
       </div>
 
       <div id="contenido-generador" class="hide">
-        
+
         <div class="info-grid">
           <div class="grid-full"><label>Nombre del Persona usuaria</label><input id="valNombreUser" readonly></div>
           <div><label>Matrícula</label><input id="valMatricula" readonly></div>
@@ -182,7 +182,7 @@
         </div>
 
         <form id="formEscrito">
-          
+
           <div class="flex-row">
             <div class="flex-col grid-full">
               <label>¿A quién va dirigido?</label>
@@ -267,7 +267,7 @@
             <i class="ph-bold ph-magic-wand"></i> Redactar con IA y Generar Documento
           </button>
         </form>
-      </div> 
+      </div>
     </div>
   </div>
 
@@ -289,9 +289,9 @@
     <div class="modal-card" style="max-width: 500px; text-align: center;">
       <h3 style="color:#fff; margin-top:0; margin-bottom: 5px;">Firma Digital</h3>
       <p style="color: var(--text-muted); font-size: 13px; margin-bottom: 20px;">Dibuja tu firma para autorizar el envío del trámite al buzón oficial.</p>
-      
+
       <canvas id="padFirma" style="background:#fff; width:100%; height:200px; border-radius:10px; border: 2px dashed #94a3b8; cursor:crosshair; margin-bottom: 20px;"></canvas>
-      
+
       <div style="display:flex; gap:10px; justify-content:center;">
         <button class="btn outline" id="btnCancelarFirma" style="width: auto; padding: 12px 20px;">Cancelar</button>
         <button class="btn success" id="btnGuardarFirma" style="width: auto; padding: 12px 20px;">Aplicar Firma</button>
@@ -301,10 +301,10 @@
 
   <div id="modalFirma" class="modal">
     <div class="modal-card">
-      
+
       <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom: 15px; flex-wrap:wrap; gap:15px;">
         <h3 id="tituloVistaPrevia" style="color:#fff; margin:0;">Vista Previa del Oficio</h3>
-        
+
         <div id="accionesNormales" class="acciones-header" style="display:flex; gap:10px; flex-wrap: wrap; justify-content: flex-end;">
           <button class="btn outline" id="btnPrint" style="padding: 10px 16px; width: auto;"><i class="ph-bold ph-printer"></i> Imprimir</button>
           <button class="btn outline" id="btnDescargar" style="padding: 10px 16px; width: auto;"><i class="ph-bold ph-download-simple"></i> Guardar PDF</button>
@@ -312,16 +312,16 @@
           <button class="btn outline" id="btnCerrarFirma" style="padding: 10px 16px; width: auto; border-color: #ef4444; color:#ef4444;"><i class="ph-bold ph-x"></i></button>
         </div>
       </div>
-      
+
       <div class="modal-b" id="modalBody">
         <div id="page" class="page carta">
           <div id="sheet" class="sheet"></div>
         </div>
       </div>
-      
+
       <div id="seccionFinalDigital" class="hide" style="margin-top: 20px; border-top: 1px solid var(--panel-border); padding-top: 20px;">
         <div class="lock-alert">
-          <i class="ph-bold ph-lock-key" style="font-size: 22px; vertical-align: middle;"></i> 
+          <i class="ph-bold ph-lock-key" style="font-size: 22px; vertical-align: middle;"></i>
           <strong>Envío a Buzón Digital bloqueado:</strong> Función disponible a partir del 16 de abril.<br>
           <span style="color: #fff; font-weight: bold; font-size: 16px; display:block; margin-top: 8px;">¡Vota Equipo Azul para hacerlo realidad!</span>
         </div>
@@ -344,7 +344,7 @@
     document.addEventListener('DOMContentLoaded', async () => {
       const $ = s => document.querySelector(s);
       const API_BASE = "https://sinos-api.onrender.com";
-      
+
       let fotosBase64 = [];
       let supabase;
       let currentUser = null;
@@ -388,10 +388,10 @@
         $('#selectCCP').innerHTML = ops.replace('— Selecciona —', 'Ninguno');
 
         const { data: { session }, error: authError } = await supabase.auth.getSession();
-        
+
         if (authError || !session) {
           alert("Acceso denegado. Debes iniciar sesión en la plataforma.");
-          window.location.href = "login.html"; 
+          window.location.href = "login.html";
           return;
         }
         currentUser = session.user;
@@ -402,14 +402,14 @@
           .eq('user_id', session.user.id)
           .maybeSingle();
 
-        $('#loader-inicial').classList.add('hide'); 
+        $('#loader-inicial').classList.add('hide');
 
         const isComplete = prof && prof.display_name && prof.matricula && prof.categoria && prof.adscripcion;
 
         if (!isComplete) {
           $('#bloqueo-perfil').classList.remove('hide');
-          return; 
-        } 
+          return;
+        }
 
         $('#contenido-generador').classList.remove('hide');
         $('#valNombreUser').value = prof.display_name;
@@ -434,8 +434,8 @@
         $('#toggleAvanzado').addEventListener('click', function() {
           const panel = $('#panelAvanzado');
           panel.classList.toggle('show');
-          this.innerHTML = panel.classList.contains('show') 
-            ? '<i class="ph-bold ph-gear-six"></i> Ocultar Opciones Avanzadas' 
+          this.innerHTML = panel.classList.contains('show')
+            ? '<i class="ph-bold ph-gear-six"></i> Ocultar Opciones Avanzadas'
             : '<i class="ph-bold ph-gear-six"></i> Mostrar Opciones Avanzadas (Copias, Evidencia)';
         });
 
@@ -471,14 +471,14 @@
         // GENERAR DOCUMENTO INICIAL (Limpio, sin folio)
         $('#formEscrito').addEventListener('submit', async (e) => {
           e.preventDefault();
-          
+
           const btnSubmit = $('#btnGenerarPrincipal');
           btnSubmit.innerHTML = "<i class='ph-bold ph-spinner anim-spin'></i> Redactando con Inteligencia Artificial...";
           btnSubmit.disabled = true;
 
           const targetSelect = $('#selectDestino');
           const [cargo, nombre] = targetSelect.value.split('|');
-          
+
           const cuerpoIA = await redactarIA($('#textoHechos').value);
           const ciudad = $('#inputCiudad').value;
           const fechaLarga = new Date($('#inputFecha').value + 'T12:00:00').toLocaleDateString('es-MX', {day:'2-digit', month:'long', year:'numeric'});
@@ -536,15 +536,15 @@
         $('#btnGuardarFirma').addEventListener('click', () => {
           // Inyectar el folio
           $('#folio-documento').innerHTML = `Folio Oficial: <strong>PENDIENTE DE ENVÍO DIGITAL</strong>`;
-          
+
           // Crear y colocar imagen de firma
           const lineaFirma = $('#linea-firma');
           let imgFirma = document.getElementById('img-firma-digital');
           if(!imgFirma) {
             imgFirma = document.createElement('img');
             imgFirma.id = 'img-firma-digital';
-            imgFirma.style.maxHeight = '80px'; 
-            imgFirma.style.margin = '10px auto 5px auto'; 
+            imgFirma.style.maxHeight = '80px';
+            imgFirma.style.margin = '10px auto 5px auto';
             imgFirma.style.display = 'block';
             lineaFirma.parentNode.insertBefore(imgFirma, lineaFirma);
           }
@@ -578,26 +578,26 @@
         // ------------------ FUNCIONALIDAD DEL CANVAS ------------------
         let dibujando = false, ctx;
         function iniciarPad() {
-          const c = $('#padFirma'); 
-          c.width = c.offsetWidth; 
+          const c = $('#padFirma');
+          c.width = c.offsetWidth;
           c.height = 200;
-          ctx = c.getContext('2d'); 
-          ctx.lineWidth = 2.5; 
-          ctx.strokeStyle = "#0f172a"; 
+          ctx = c.getContext('2d');
+          ctx.lineWidth = 2.5;
+          ctx.strokeStyle = "#0f172a";
           ctx.lineCap = "round";
           ctx.lineJoin = "round";
-          ctx.clearRect(0,0,c.width,c.height); 
-          
+          ctx.clearRect(0,0,c.width,c.height);
+
           c.onmousedown = c.ontouchstart = (e) => { dibujando = true; ctx.beginPath(); e.preventDefault(); };
-          c.onmousemove = c.ontouchmove = (e) => { 
-            if(!dibujando) return; 
+          c.onmousemove = c.ontouchmove = (e) => {
+            if(!dibujando) return;
             const rect = c.getBoundingClientRect();
             const clientX = e.clientX || (e.touches && e.touches[0].clientX);
             const clientY = e.clientY || (e.touches && e.touches[0].clientY);
             if (clientX !== undefined && clientY !== undefined) {
               const x = clientX - rect.left;
               const y = clientY - rect.top;
-              ctx.lineTo(x, y); 
+              ctx.lineTo(x, y);
               ctx.stroke();
             }
           };
@@ -609,10 +609,10 @@
           // Cambiamos el nombre del documento para que al imprimir/guardar tenga el nombre correcto
           const originalTitle = document.title;
           document.title = `Oficio_PSC_${$('#valMatricula').value}`;
-          
+
           // Lanzamos el cuadro de impresión (el CSS hace todo el trabajo de limpieza visual)
           window.print();
-          
+
           // Restauramos el nombre original de la pestaña
           document.title = originalTitle;
         });
@@ -624,8 +624,8 @@
 
           const pageEl = $('#page');
           const originalTransform = pageEl.style.transform;
-          pageEl.style.transform = 'scale(1)'; 
-          
+          pageEl.style.transform = 'scale(1)';
+
           try {
             const { jsPDF } = window.jspdf;
             const doc = new jsPDF({ unit: 'pt', format: 'letter' });
@@ -656,7 +656,7 @@
               doc.addImage(imgData, 'JPEG', 0, position, pdfWidth, imgHeight);
               heightLeft -= pdfHeight;
             }
-            
+
             fotosBase64.forEach((img, i) => {
               doc.addPage();
               doc.setFontSize(14); doc.setFont("helvetica", "bold");
@@ -665,7 +665,7 @@
             });
 
             doc.save(`Oficio_PSC_${$('#valMatricula').value}.pdf`);
-            
+
           } catch (e) {
             console.error(e);
             alert("Error al descargar el PDF: " + e.message);

--- a/descargar.html
+++ b/descargar.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Descarga Oficial - Plataforma Comunitaria Digital</title>
-    
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -14,23 +14,23 @@
 
     <style>
         :root {
-            --bg-body: #1b2e45; 
-            --bg-body-end: #152336;
+            --bg-body: #004b33;
+            --bg-body-end: #003423;
             --panel-base: 46, 79, 119;
-            --primary: #4da1a8; 
-            --primary-light: #7ad1d6;
+            --primary: #006341;
+            --primary-light: #8fd9b6;
             --success: #4ade80;
-            --text-main: #f0fdfa; 
+            --text-main: #f0fdfa;
             --text-muted: #bce9eb;
-            --ring: rgba(77, 161, 168, .35);
+            --ring: rgba(0, 99, 65, .35);
         }
 
-        body { 
-            font-family: 'Inter', sans-serif; 
-            background-color: transparent; 
-            color: var(--text-main); 
-            margin: 0; 
-            padding: 20px; 
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: transparent;
+            color: var(--text-main);
+            margin: 0;
+            padding: 20px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -57,17 +57,17 @@
             background-size: 40px 40px;
         }
 
-        .container { 
-            max-width: 700px; 
+        .container {
+            max-width: 700px;
             width: 100%;
-            margin: 0 auto; 
-            padding: 32px; 
-            background: rgba(var(--panel-base), 0.35); 
+            margin: 0 auto;
+            padding: 32px;
+            background: rgba(var(--panel-base), 0.35);
             backdrop-filter: blur(16px);
             -webkit-backdrop-filter: blur(16px);
-            border: 1px solid var(--ring); 
-            border-radius: 16px; 
-            box-shadow: 0 10px 40px rgba(0,0,0,0.3); 
+            border: 1px solid var(--ring);
+            border-radius: 16px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.3);
             position: relative;
             z-index: 1;
         }
@@ -81,65 +81,65 @@
         }
 
         .badge-org {
-            background: rgba(77, 161, 168, .15); 
-            border: 1px solid var(--ring); 
-            color: var(--primary-light); 
-            padding: 6px 14px; 
-            border-radius: 8px; 
-            font-size: 12px; 
-            font-weight: 600; 
-            text-transform: uppercase; 
-            display: inline-flex; 
-            align-items: center; 
+            background: rgba(0, 99, 65, .15);
+            border: 1px solid var(--ring);
+            color: var(--primary-light);
+            padding: 6px 14px;
+            border-radius: 8px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            display: inline-flex;
+            align-items: center;
             gap: 6px;
         }
 
         h1 { font-size: 26px; margin: 0 0 12px 0; font-weight: 700; text-align: center; }
         .subtitle { font-size: 15px; line-height: 1.6; color: var(--text-muted); text-align: center; margin-bottom: 24px;}
-        
-        .security-badge { 
-            display: inline-flex; 
-            align-items: center; 
-            justify-content: center; 
+
+        .security-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             gap: 8px;
-            background-color: rgba(74, 222, 128, 0.1); 
-            color: var(--success); 
-            padding: 10px 20px; 
-            border-radius: 8px; 
+            background-color: rgba(74, 222, 128, 0.1);
+            color: var(--success);
+            padding: 10px 20px;
+            border-radius: 8px;
             border: 1px solid rgba(74, 222, 128, 0.3);
-            margin: 0 auto 24px auto; 
-            font-weight: 600; 
+            margin: 0 auto 24px auto;
+            font-weight: 600;
             font-size: 13px;
         }
 
         .btn-wrapper { text-align: center; margin: 30px 0; }
-        
-        .download-btn { 
-            display: inline-flex; 
+
+        .download-btn {
+            display: inline-flex;
             align-items: center;
             gap: 10px;
-            background-color: var(--primary); 
-            color: var(--bg-body); 
-            padding: 16px 32px; 
-            text-decoration: none; 
-            font-weight: 700; 
-            border-radius: 8px; 
-            font-size: 16px; 
+            background-color: var(--primary);
+            color: var(--bg-body);
+            padding: 16px 32px;
+            text-decoration: none;
+            font-weight: 700;
+            border-radius: 8px;
+            font-size: 16px;
             transition: all 0.2s ease;
-            box-shadow: 0 4px 15px rgba(77, 161, 168, 0.3);
+            box-shadow: 0 4px 15px rgba(0, 99, 65, 0.3);
         }
-        .download-btn:hover { 
-            background-color: var(--primary-light); 
+        .download-btn:hover {
+            background-color: var(--primary-light);
             transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(77, 161, 168, 0.4);
+            box-shadow: 0 6px 20px rgba(0, 99, 65, 0.4);
         }
 
-        .steps { 
-            background-color: rgba(21, 35, 54, 0.6); 
-            padding: 24px; 
-            border-left: 4px solid var(--primary); 
+        .steps {
+            background-color: rgba(21, 35, 54, 0.6);
+            padding: 24px;
+            border-left: 4px solid var(--primary);
             border-radius: 0 12px 12px 0;
-            margin-top: 30px; 
+            margin-top: 30px;
             border-top: 1px solid var(--ring);
             border-right: 1px solid var(--ring);
             border-bottom: 1px solid var(--ring);
@@ -151,11 +151,11 @@
         li strong { color: var(--text-main); }
         code { background: rgba(var(--panel-base), 0.5); padding: 3px 6px; border-radius: 4px; border: 1px solid var(--ring); color: var(--primary-light); font-family: monospace;}
 
-        .footer { 
-            text-align: center; 
-            font-size: 12px; 
-            color: var(--text-muted); 
-            margin-top: 40px; 
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            color: var(--text-muted);
+            margin-top: 40px;
             border-top: 1px solid var(--ring);
             padding-top: 24px;
         }
@@ -172,10 +172,10 @@
     <div class="ambient-bg"></div>
 
     <div class="container">
-        
+
         <div style="text-align: center;">
             <div class="security-badge">
-                <i class="ph-fill ph-shield-check" style="font-size: 18px;"></i> 
+                <i class="ph-fill ph-shield-check" style="font-size: 18px;"></i>
                 Descarga 100% Segura y Verificada
             </div>
         </div>

--- a/directorio.html
+++ b/directorio.html
@@ -14,23 +14,23 @@
   <style>
     :root {
       /* --- PALETA SInOS --- */
-      --bg-body: #1b2e45;
-      --bg-body-end: #152336;
+      --bg-body: #004b33;
+      --bg-body-end: #003423;
       --panel-base: 46, 79, 119;
 
-      --primary: #4da1a8;
-      --primary-light: #7ad1d6;
-      --primary-dark: #3b8288;
+      --primary: #006341;
+      --primary-light: #8fd9b6;
+      --primary-dark: #00573a;
 
       --text-main: #f0fdfa;
       --text-muted: #bce9eb;
 
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
       --radius: 12px;
 
       /* Glassmorphism */
       --glass-bg: rgba(46, 79, 119, 0.35);
-      --glass-border: rgba(77, 161, 168, 0.25);
+      --glass-border: rgba(0, 99, 65, 0.25);
       --glass-highlight: rgba(255, 255, 255, 0.05);
     }
 
@@ -80,7 +80,7 @@
       padding: 8px; border-radius: 8px;
       transition: background 0.2s;
     }
-    .nav-btn:hover { background: rgba(77, 161, 168, 0.15); }
+    .nav-btn:hover { background: rgba(0, 99, 65, 0.15); }
 
     .page-title {
       font-size: 16px; font-weight: 600; color: var(--text-main);
@@ -103,7 +103,7 @@
     }
 
     .input-group { position: relative; display: flex; align-items: center; }
-    
+
     .input-icon {
       position: absolute; left: 12px;
       color: var(--primary); font-size: 18px; pointer-events: none;
@@ -119,12 +119,12 @@
       font-family: inherit; font-size: 14px;
       outline: none; transition: all 0.2s;
     }
-    
+
     .select-control { padding-left: 12px; } /* Selects sin icono */
 
     .form-control:focus {
       border-color: var(--primary);
-      box-shadow: 0 0 0 2px rgba(77, 161, 168, 0.2);
+      box-shadow: 0 0 0 2px rgba(0, 99, 65, 0.2);
     }
     .form-control::placeholder { color: var(--text-muted); opacity: 0.6; }
 
@@ -171,7 +171,7 @@
       font-size: 16px; font-weight: 700; color: #fff;
       line-height: 1.3;
     }
-    
+
     .vacant-name { color: var(--text-muted); font-style: italic; opacity: 0.6; }
 
     /* Zona de Teléfonos */
@@ -206,7 +206,7 @@
     }
 
     .btn-call {
-      background: rgba(77, 161, 168, 0.2); color: var(--primary-light);
+      background: rgba(0, 99, 65, 0.2); color: var(--primary-light);
     }
     .btn-call:hover { background: var(--primary); color: #fff; }
 
@@ -244,20 +244,20 @@
   </header>
 
   <main class="container">
-    
+
     <section class="controls">
       <div class="input-group">
         <i class="ph-bold ph-magnifying-glass input-icon"></i>
         <input id="q" class="form-control" type="search" placeholder="Buscar nombre, cargo..." autocomplete="off" />
       </div>
-      
+
       <select id="cat" class="form-control select-control">
         <option value="__all__">Todas las áreas</option>
         <option value="Secretarías">Secretarías</option>
         <option value="Comisiones">Comisiones</option>
         <option value="Subcomisiones">Subcomisiones</option>
       </select>
-      
+
       <select id="sort" class="form-control select-control">
         <option value="area-asc">Orden: Cargo</option>
         <option value="name-asc">Orden: A - Z</option>
@@ -266,7 +266,7 @@
     </section>
 
     <section id="results" class="grid"></section>
-    
+
     <div id="empty" class="empty-state" hidden>
       <i class="ph-duotone ph-ghost" style="font-size:32px; display:block; margin:0 auto 10px;"></i>
       No se encontraron coincidencias.
@@ -354,11 +354,11 @@
 
       for (const item of list) {
         const isVacant = item.n.toUpperCase?.().includes('VACANTE');
-        
+
         // Crear Tarjeta
         const card = document.createElement('article');
         card.className = 'card';
-        
+
         // HTML interno de la tarjeta
         let phonesHtml = '';
         if(item.p && item.p.length > 0) {

--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,7 @@
       'https://tuperfil.imss.gob.mx',
       'https://www.facebook.com'
     ]);
-    const shouldOpenOutsideIframe = (app) => {
+    window.shouldOpenOutsideIframe = window.shouldOpenOutsideIframe || function (app) {
       if (!app) return false;
       return app.id === 'perfil-imss' || app.id === 'tarjeton';
     };
@@ -1201,7 +1201,7 @@
 
           tile.onclick = () => {
             const url = a.href || a.iframe;
-            if (shouldOpenOutsideIframe(a)) {
+            if (window.shouldOpenOutsideIframe(a)) {
               this.openSafeExternal(url);
             } else {
               this.openApp(a.id);
@@ -1244,7 +1244,7 @@
         desc.textContent = app.desc;
         iconWrap.innerHTML = `<i class="${app.iconClass}"></i>`;
         const target = app.iframe || app.href || 'about:blank';
-        if (shouldOpenOutsideIframe(app)) {
+        if (window.shouldOpenOutsideIframe(app)) {
           this.openSafeExternal(target);
           this.goHome();
           return;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta property="og:image" content="https://raw.githubusercontent.com/ChronosBVRX/PlataformaComunitaria/main/Logo%20PSC.jpeg" />
 
   <link rel="manifest" href="./manifest.json">
-  <meta name="theme-color" content="#1b2e45">
+  <meta name="theme-color" content="#006341">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="PSD">
@@ -49,16 +49,16 @@
 
   <style>
     :root {
-      --bg-body: #1b2e45;
-      --bg-body-end: #152336;
-      --panel-base: 46, 79, 119;
-      --primary: #4da1a8;
-      --primary-light: #7ad1d6;
-      --success: #4ade80;
+      --bg-body: #004b33;
+      --bg-body-end: #003423;
+      --panel-base: 0, 99, 65;
+      --primary: #006341;
+      --primary-light: #8fd9b6;
+      --success: #50c878;
       --danger: #ff7b7b;
-      --text-main: #f0fdfa;
-      --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
+      --text-main: #edf7f1;
+      --text-muted: #c7dfd2;
+      --ring: rgba(0, 168, 107, .28);
       --topbar: 64px;
       --radius: 16px;
       --glass-bg: rgba(var(--panel-base), 0.35);
@@ -122,7 +122,7 @@
       width: 36px;
       height: 36px;
       border-radius: 8px;
-      background: rgba(77, 161, 168, .15);
+      background: rgba(0, 168, 107, .16);
       border: 1px solid var(--ring);
       overflow: hidden;
       display: grid;
@@ -171,7 +171,7 @@
     }
 
     .btn-ai-topbar {
-      background: rgba(77, 161, 168, 0.15);
+      background: rgba(0, 99, 65, 0.15);
       color: var(--primary-light);
       border: 1px solid var(--primary-light);
       padding: 8px 12px;
@@ -188,7 +188,7 @@
     .btn-ai-topbar:hover {
       background: var(--primary-light);
       color: var(--bg-body);
-      box-shadow: 0 0 10px rgba(122, 209, 214, 0.4);
+      box-shadow: 0 0 12px rgba(0, 168, 107, 0.35);
     }
 
     .btn-auth {
@@ -294,13 +294,13 @@
 
     .icon-illuminated {
       color: var(--primary-light) !important;
-      filter: drop-shadow(0 0 8px rgba(122, 209, 214, 0.6));
+      filter: drop-shadow(0 0 8px rgba(143, 217, 182, 0.6));
     }
 
     @keyframes pulseGlow {
-      0% { box-shadow: 0 0 0 0 rgba(122, 209, 214, 0.7), 0 0 0 2px var(--bg-body); }
-      70% { box-shadow: 0 0 0 6px rgba(122, 209, 214, 0), 0 0 0 2px var(--bg-body); }
-      100% { box-shadow: 0 0 0 0 rgba(122, 209, 214, 0), 0 0 0 2px var(--bg-body); }
+      0% { box-shadow: 0 0 0 0 rgba(143, 217, 182, 0.7), 0 0 0 2px var(--bg-body); }
+      70% { box-shadow: 0 0 0 6px rgba(143, 217, 182, 0), 0 0 0 2px var(--bg-body); }
+      100% { box-shadow: 0 0 0 0 rgba(143, 217, 182, 0), 0 0 0 2px var(--bg-body); }
     }
 
     .layer {
@@ -349,7 +349,7 @@
     }
 
     .badge {
-      background: rgba(77, 161, 168, .15);
+      background: rgba(0, 168, 107, .16);
       border: 1px solid var(--ring);
       color: var(--primary-light);
       padding: 6px 14px;
@@ -393,9 +393,9 @@
     }
 
     .tile.featured {
-      background: linear-gradient(145deg, rgba(77, 161, 168, 0.2), rgba(var(--panel-base), 0.45));
+      background: linear-gradient(145deg, rgba(0, 99, 65, 0.2), rgba(var(--panel-base), 0.45));
       border: 1px solid var(--primary-light);
-      box-shadow: 0 0 15px rgba(77, 161, 168, 0.15);
+      box-shadow: 0 0 15px rgba(0, 99, 65, 0.15);
     }
 
     .tile-icon-integrated {
@@ -403,7 +403,7 @@
       color: var(--primary-light);
       margin-bottom: 16px;
       transition: all 0.3s ease;
-      filter: drop-shadow(0 4px 6px rgba(77, 161, 168, 0.4));
+      filter: drop-shadow(0 4px 6px rgba(0, 99, 65, 0.4));
     }
 
     .tile h3 { margin: 0 0 8px 0; font-size: 18px; }
@@ -421,9 +421,9 @@
       font-size: 11px;
       font-weight: 700;
       color: var(--primary-light);
-      background: rgba(77, 161, 168, .14);
+      background: rgba(0, 99, 65, .14);
       border: 1px solid var(--ring);
-      box-shadow: 0 0 8px rgba(122, 209, 214, 0.2);
+      box-shadow: 0 0 8px rgba(143, 217, 182, 0.2);
     }
 
     .download-strip {
@@ -491,7 +491,7 @@
       backdrop-filter: blur(8px);
       padding: 8px 12px;
       border-radius: 40px;
-      border: 1px solid rgba(122, 209, 214, 0.2);
+      border: 1px solid rgba(143, 217, 182, 0.25);
       box-shadow: 0 10px 30px rgba(0,0,0,0.6);
     }
 
@@ -548,7 +548,7 @@
       display: grid;
       place-items: center;
       z-index: 100;
-      background: radial-gradient(circle at center, #1b2e45 0%, #0a141d 100%);
+      background: radial-gradient(circle at center, #004b33 0%, #0a141d 100%);
       transition: opacity 0.6s ease;
       padding: 20px;
       text-align: center;
@@ -560,7 +560,7 @@
       border-radius: 22px;
       border: 1px solid var(--ring);
       overflow: hidden;
-      box-shadow: 0 0 30px rgba(77,161,168,0.3);
+      box-shadow: 0 0 30px rgba(0,168,107,0.28);
       margin: 0 auto 20px;
     }
 
@@ -712,7 +712,7 @@
       backdrop-filter: blur(16px);
       border: 1px solid var(--primary-light);
       border-radius: 16px;
-      box-shadow: 0 10px 40px rgba(0,0,0,0.5), 0 0 20px rgba(77, 161, 168, 0.2);
+      box-shadow: 0 10px 40px rgba(0,0,0,0.5), 0 0 20px rgba(0, 168, 107, 0.18);
       overflow: hidden;
       transition: all 0.3s ease;
       transform: translateY(20px) scale(0.95);
@@ -767,9 +767,9 @@
     }
 
     @keyframes aiPulse {
-      0% { box-shadow: 0 0 0 0 rgba(122, 209, 214, 0.6); }
-      70% { box-shadow: 0 0 0 12px rgba(122, 209, 214, 0); }
-      100% { box-shadow: 0 0 0 0 rgba(122, 209, 214, 0); }
+      0% { box-shadow: 0 0 0 0 rgba(0, 168, 107, 0.55); }
+      70% { box-shadow: 0 0 0 12px rgba(0, 168, 107, 0); }
+      100% { box-shadow: 0 0 0 0 rgba(0, 168, 107, 0); }
     }
 
     .chatbot-bubble {
@@ -1051,6 +1051,10 @@
       'https://tuperfil.imss.gob.mx',
       'https://www.facebook.com'
     ]);
+    const shouldOpenOutsideIframe = (app) => {
+      if (!app) return false;
+      return app.id === 'perfil-imss' || app.id === 'tarjeton';
+    };
 
     const APPS = [
       { id: 'buzon', title: 'Buzón de Atención', desc: 'Trámites y respuestas.', iconClass: 'ph-duotone ph-envelope-open', iframe: 'buzon.html', featured: true, hideFromMenu: true },
@@ -1197,7 +1201,7 @@
 
           tile.onclick = () => {
             const url = a.href || a.iframe;
-            if (a.newTab || (url && url.includes('imss.gob.mx'))) {
+            if (shouldOpenOutsideIframe(a)) {
               this.openSafeExternal(url);
             } else {
               this.openApp(a.id);
@@ -1239,7 +1243,13 @@
         title.textContent = app.title;
         desc.textContent = app.desc;
         iconWrap.innerHTML = `<i class="${app.iconClass}"></i>`;
-        iframe.src = app.iframe || app.href || 'about:blank';
+        const target = app.iframe || app.href || 'about:blank';
+        if (shouldOpenOutsideIframe(app)) {
+          this.openSafeExternal(target);
+          this.goHome();
+          return;
+        }
+        iframe.src = target;
       },
 
       goHome() {

--- a/kiosko.html
+++ b/kiosko.html
@@ -8,17 +8,17 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/@phosphor-icons/web"></script>
-  
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 
   <style>
     :root {
-      --bg-body: #1b2e45; --bg-body-end: #152336;
+      --bg-body: #004b33; --bg-body-end: #003423;
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; --primary-light: #7ad1d6;
+      --primary: #006341; --primary-light: #8fd9b6;
       --text-main: #f0fdfa; --text-muted: #bce9eb;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
       --radius: 16px;
       --glass-bg: rgba(var(--panel-base), 0.35);
     }
@@ -33,7 +33,7 @@
 
     body::before {
       content: ""; position: absolute; inset: 0; opacity: .06; z-index: -1;
-      background-image: linear-gradient(to right, var(--primary) 1px, transparent 1px), 
+      background-image: linear-gradient(to right, var(--primary) 1px, transparent 1px),
                         linear-gradient(to bottom, var(--primary) 1px, transparent 1px);
       background-size: 40px 40px;
     }
@@ -46,7 +46,7 @@
       display: flex; align-items: center; gap: 8px; font-size: 14px;
       font-weight: 600; transition: 0.3s; z-index: 50;
     }
-    .btn-flotante:hover { background: rgba(77, 161, 168, 0.2); color: var(--primary-light); }
+    .btn-flotante:hover { background: rgba(0, 99, 65, 0.2); color: var(--primary-light); }
 
     .container { width: 100%; max-width: 900px; padding: 40px; text-align: center; }
 
@@ -59,27 +59,27 @@
     p.subtitle { color: var(--text-muted); font-size: 18px; margin-bottom: 40px; }
 
     .options-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
-    
+
     .card-btn {
       background: var(--glass-bg); backdrop-filter: blur(12px); border: 1px solid var(--ring);
       border-radius: var(--radius); padding: 40px 20px; cursor: pointer; transition: all 0.3s ease;
       display: flex; flex-direction: column; align-items: center; gap: 16px;
     }
-    
+
     .card-btn:hover {
       border-color: var(--primary-light); background: rgba(var(--panel-base), 0.6);
-      transform: translateY(-5px); box-shadow: 0 10px 30px rgba(77, 161, 168, 0.2);
+      transform: translateY(-5px); box-shadow: 0 10px 30px rgba(0, 99, 65, 0.2);
     }
-    
+
     .card-btn i { font-size: 64px; color: var(--primary-light); }
     .card-btn h3 { margin: 0; font-size: 20px; }
     .card-btn p { margin: 0; font-size: 13px; color: var(--text-muted); }
 
     .qr-box {
       background: white; padding: 20px; border-radius: var(--radius);
-      display: inline-block; margin: 20px 0; box-shadow: 0 0 40px rgba(77,161,168,0.3);
+      display: inline-block; margin: 20px 0; box-shadow: 0 0 40px rgba(0,99,65,0.3);
     }
-    
+
     .session-id { font-family: monospace; font-size: 24px; color: var(--primary-light); letter-spacing: 2px; margin-top: 10px; }
 
     /* Contenedor flexible para imagen o PDF */
@@ -98,30 +98,30 @@
       display: inline-flex; align-items: center; gap: 10px; transition: 0.3s;
     }
     .btn-action:hover { background: var(--primary-light); transform: scale(1.05); }
-    
+
     .btn-secondary { background: transparent; color: var(--text-main); border: 1px solid var(--ring); }
     .btn-secondary:hover { background: rgba(255,255,255,0.1); }
 
     @media print {
       body * { visibility: hidden !important; }
       body { background: white !important; }
-      
-      #doc-image, #doc-pdf { 
-        visibility: visible !important; 
-        position: absolute !important; 
-        left: 0 !important; 
-        top: 0 !important; 
-        width: 100vw !important; 
-        height: 100vh !important; 
-        max-width: none !important; 
+
+      #doc-image, #doc-pdf {
+        visibility: visible !important;
+        position: absolute !important;
+        left: 0 !important;
+        top: 0 !important;
+        width: 100vw !important;
+        height: 100vh !important;
+        max-width: none !important;
         max-height: none !important;
-        border: none !important; 
-        margin: 0 !important; 
-        padding: 0 !important; 
+        border: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
         border-radius: 0 !important;
       }
       #doc-image { object-fit: contain !important; }
-      
+
       @page { margin: 0; size: auto; }
     }
   </style>
@@ -133,18 +133,18 @@
   </button>
 
   <div class="container">
-    
+
     <div id="view-menu" class="view active">
       <h1>Kiosko de Recepción Digital</h1>
       <p class="subtitle">Selecciona el tipo de documento que deseas enviar con tu celular</p>
-      
+
       <div class="options-grid">
         <div class="card-btn" onclick="iniciarSesion('identificacion')">
           <i class="ph-duotone ph-identification-card"></i>
           <h3>Identificación</h3>
           <p>Escanea frente y reverso.<br>Impresión en una hoja.</p>
         </div>
-        
+
         <div class="card-btn" onclick="iniciarSesion('documento')">
           <i class="ph-duotone ph-file-text"></i>
           <h3>Escáner Físico</h3>
@@ -162,10 +162,10 @@
     <div id="view-qr" class="view">
       <h1>Conecta tu Celular</h1>
       <p class="subtitle">Apunta con la cámara de tu celular a este código para continuar.</p>
-      
+
       <div class="qr-box" id="qrcode"></div>
       <div>ID de Sesión: <span id="session-display" class="session-id">----</span></div>
-      
+
       <br><br>
       <button class="btn-action btn-secondary" onclick="mostrarVista('view-menu')">
         <i class="ph-bold ph-arrow-left"></i> Cancelar y Volver
@@ -175,12 +175,12 @@
     <div id="view-result" class="view">
       <h1>¡Documento Recibido!</h1>
       <p class="subtitle">Verifica que sea correcto antes de imprimir.</p>
-      
+
       <div class="document-preview-container">
         <img id="doc-image" src="" alt="Vista previa del documento">
         <iframe id="doc-pdf" src=""></iframe>
       </div>
-      
+
       <div style="display: flex; gap: 20px; justify-content: center;">
         <button class="btn-action" onclick="imprimirDocumento()">
           <i class="ph-bold ph-printer"></i> Imprimir Ahora
@@ -196,7 +196,7 @@
   <script>
     let qrCodeObj = null;
     let sesionActual = '';
-    
+
     const API_URL = 'https://sinos-api.onrender.com';
     const socket = io(API_URL);
 
@@ -211,7 +211,7 @@
       if (archivoBase64 && archivoBase64.startsWith('data:application/pdf')) {
         imgPreview.style.display = 'none';
         pdfPreview.style.display = 'block';
-        
+
         // Convertimos el Base64 a un Blob URL para que el iframe lo cargue perfecto sin romperse
         fetch(archivoBase64)
           .then(res => res.blob())
@@ -227,7 +227,7 @@
         imgPreview.style.display = 'block';
         imgPreview.src = archivoBase64;
       }
-      
+
       mostrarVista('view-result');
     });
 
@@ -244,8 +244,8 @@
       const urlParaCelular = `${baseUrl}celular.html?sesion=${sesionActual}&tipo=${tipo}`;
 
       const contenedorQR = document.getElementById('qrcode');
-      contenedorQR.innerHTML = ''; 
-      
+      contenedorQR.innerHTML = '';
+
       qrCodeObj = new QRCode(contenedorQR, {
         text: urlParaCelular,
         width: 250, height: 250,
@@ -259,7 +259,7 @@
 
     function imprimirDocumento() {
       const pdfPreview = document.getElementById('doc-pdf');
-      
+
       if (pdfPreview.style.display === 'block') {
         try {
           // Disparamos la impresión directa del PDF en el iframe

--- a/login.html
+++ b/login.html
@@ -8,14 +8,14 @@
 <style>
   :root{
     /* ✅ Paleta oficial — Plataforma Comunitaria CG */
-    --bg:#1b2e45;          /* body */
-    --bg2:#152336;         /* degradado */
+    --bg:#004b33;          /* body */
+    --bg2:#003423;         /* degradado */
     --panel:#2e4f77;       /* cards */
-    --ring:rgba(77,161,168,.35); /* bordes/anillos */
+    --ring:rgba(0,99,65,.35); /* bordes/anillos */
     --txt:#f0fdfa;         /* texto principal */
     --muted:#bce9eb;       /* texto secundario */
-    --accent:#4da1a8;      /* primary */
-    --sky:#7ad1d6;         /* sky */
+    --accent:#006341;      /* primary */
+    --sky:#8fd9b6;         /* sky */
     --err:#ff7b7b;
   }
 
@@ -25,8 +25,8 @@
     height:100%; margin:0; color:var(--txt);
     font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;
     background:
-      radial-gradient(70vmax 70vmax at 50% 20%, rgba(77,161,168,.18), transparent 60%),
-      radial-gradient(60vmax 60vmax at 80% 80%, rgba(122,209,214,.12), transparent 60%),
+      radial-gradient(70vmax 70vmax at 50% 20%, rgba(0,99,65,.18), transparent 60%),
+      radial-gradient(60vmax 60vmax at 80% 80%, rgba(143,217,182,.12), transparent 60%),
       linear-gradient(180deg,var(--bg2),var(--bg));
   }
 
@@ -58,7 +58,7 @@
   .tab{
     appearance:none;
     border:1px solid var(--ring);
-    background:rgba(77,161,168,.12);
+    background:rgba(0,99,65,.12);
     color:var(--txt);
     border-radius:12px;
     padding:8px 12px;
@@ -83,8 +83,8 @@
     outline:none;
   }
   input:focus, select:focus{
-    border-color: rgba(122,209,214,.65);
-    box-shadow: 0 0 0 4px rgba(77,161,168,.18);
+    border-color: rgba(143,217,182,.65);
+    box-shadow: 0 0 0 4px rgba(0,99,65,.18);
   }
 
   .grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
@@ -94,7 +94,7 @@
   .btn{
     appearance:none;
     border:1px solid var(--ring);
-    background:rgba(77,161,168,.12);
+    background:rgba(0,99,65,.12);
     color:var(--txt);
     border-radius:12px;
     padding:10px 14px;
@@ -151,8 +151,8 @@
   }
   .combo-item:hover,
   .combo-item.active{
-    background:rgba(77,161,168,.18);
-    outline:1px solid rgba(77,161,168,.25);
+    background:rgba(0,99,65,.18);
+    outline:1px solid rgba(0,99,65,.25);
   }
   .combo-empty{
     padding:10px 10px;

--- a/miembros.html
+++ b/miembros.html
@@ -8,20 +8,20 @@
   <link rel="icon" href="https://raw.githubusercontent.com/ChronosBVRX/PlataformaComunitaria/refs/heads/main/Logo%20PSC.jpeg">
   <style>
     :root {
-      --bg: #1b2e45;
+      --bg: #004b33;
       --panel: #2e4f77;
-      --ring: rgba(77, 161, 168, .45);
+      --ring: rgba(0, 99, 65, .45);
       --txt: #f0fdfa;
       --muted: #bce9eb;
-      --primary: #4da1a8;
-      --sky: #7ad1d6;
+      --primary: #006341;
+      --sky: #8fd9b6;
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto; }
 
     body {
       min-height: 100vh;
-      background: linear-gradient(180deg, #152336, #1b2e45);
+      background: linear-gradient(180deg, #003423, #004b33);
       color: var(--txt);
       display: flex;
       flex-direction: column;
@@ -73,7 +73,7 @@
     nav { width: 240px; background: transparent; padding: 12px; display: flex; flex-direction: column; gap: 10px; }
 
     nav button {
-      appearance: none; border: none; background: rgba(77, 161, 168, .12); color: var(--txt);
+      appearance: none; border: none; background: rgba(0, 99, 65, .12); color: var(--txt);
       padding: 10px 14px; border-radius: 10px; text-align: left; cursor: pointer; transition: .2s; font-size: 14px;
     }
 
@@ -82,7 +82,7 @@
     section.content { flex: 1; padding: 12px 20px 20px; display: none; min-width: 0; }
     section.content.active { display: block; animation: fade .4s ease; }
 
-    .card { background: var(--panel); border: 1px solid rgba(77, 161, 168, .35); border-radius: 16px; padding: 24px; box-shadow: 0 8px 25px rgba(0, 0, 0, .25); }
+    .card { background: var(--panel); border: 1px solid rgba(0, 99, 65, .35); border-radius: 16px; padding: 24px; box-shadow: 0 8px 25px rgba(0, 0, 0, .25); }
 
     @keyframes fade { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 
@@ -102,7 +102,7 @@
     form { display: grid; gap: 12px; max-width: 600px; margin-top: 16px; }
     label { font-size: 13px; color: #bce9eb; margin-bottom: -4px; }
     input, textarea, select {
-      background: #152336; border: 1px solid rgba(77, 161, 168, .4); color: #f0fdfa; padding: 10px 12px; border-radius: 10px; font-size: 14px;
+      background: #003423; border: 1px solid rgba(0, 99, 65, .4); color: #f0fdfa; padding: 10px 12px; border-radius: 10px; font-size: 14px;
     }
     textarea { min-height: 90px; resize: vertical; }
 
@@ -113,14 +113,14 @@
     .btn:hover { filter: brightness(1.12); }
 
     .subtle-btn {
-      appearance: none; border: 1px solid rgba(77, 161, 168, .28); background: rgba(77, 161, 168, .1);
+      appearance: none; border: 1px solid rgba(0, 99, 65, .28); background: rgba(0, 99, 65, .1);
       color: #fff; padding: 6px 10px; border-radius: 10px; cursor: pointer; font-size: 13px;
     }
-    .subtle-btn:hover { background: rgba(77, 161, 168, .25); }
+    .subtle-btn:hover { background: rgba(0, 99, 65, .25); }
 
     .pill {
       display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 999px;
-      background: rgba(77, 161, 168, .15); border: 1px solid rgba(77, 161, 168, .35); font-size: 12px; color: #d1f5f7;
+      background: rgba(0, 99, 65, .15); border: 1px solid rgba(0, 99, 65, .35); font-size: 12px; color: #d1f5f7;
     }
 
     .meta { font-size: 12px; color: #8ccacdb6; }
@@ -130,17 +130,17 @@
     .perfil-main { flex: 2; display: flex; flex-direction: column; gap: 16px; }
     .perfil-extra { flex: 1.3; display: flex; flex-direction: column; gap: 12px; }
 
-    .perfil-extra-card { background: #233b5c; border: 1px solid rgba(77, 161, 168, .35); border-radius: 12px; padding: 14px 16px; }
+    .perfil-extra-card { background: #233b5c; border: 1px solid rgba(0, 99, 65, .35); border-radius: 12px; padding: 14px 16px; }
     .perfil-extra-card h3 { margin: 0 0 8px; font-size: 15px; color: #d1f5f7; }
 
     #perfilQuoteText { font-size: 14px; color: var(--txt); line-height: 1.5; font-style: italic; }
     #perfilQuoteTag { display: block; margin-top: 6px; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--primary); }
 
     .btn-mini {
-      margin-top: 10px; font-size: 12px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(77, 161, 168, .6);
+      margin-top: 10px; font-size: 12px; padding: 6px 12px; border-radius: 999px; border: 1px solid rgba(0, 99, 65, .6);
       background: rgba(21, 35, 54, 0.9); color: #f0fdfa; cursor: pointer;
     }
-    .btn-mini:hover { background: rgba(77, 161, 168, .25); }
+    .btn-mini:hover { background: rgba(0, 99, 65, .25); }
 
     #perfilValorList, #perfilAccionesList { margin-left: 18px; font-size: 14px; color: var(--muted); }
     #perfilValorList li+li, #perfilAccionesList li+li { margin-top: 6px; }
@@ -151,7 +151,7 @@
       background: rgba(120, 53, 15, .5); font-size: 10px; text-transform: uppercase; letter-spacing: .12em; color: #fed7aa; margin-bottom: 6px;
     }
 
-    .escalafon-promo { margin-top: 20px; padding: 16px; border: 1px dashed var(--sky); border-radius: 12px; background: rgba(122, 209, 214, 0.05); }
+    .escalafon-promo { margin-top: 20px; padding: 16px; border: 1px dashed var(--sky); border-radius: 12px; background: rgba(143, 217, 182, 0.05); }
     .blur-box { background: rgba(0, 0, 0, 0.2); padding: 12px; border-radius: 8px; position: relative; overflow: hidden; margin-top: 10px; }
     .blur-text { filter: blur(5px); user-select: none; font-size: 14px; }
     .promo-overlay {
@@ -163,7 +163,7 @@
 
     @media (min-width: 980px) { .perfil-layout { flex-direction: row; align-items: flex-start; } }
     @media (max-width: 980px) {
-      nav { width: 100%; flex-direction: row; position: sticky; top: 60px; z-index: 9; overflow-x: auto; background: var(--bg); border-bottom: 1px solid rgba(77,161,168,.25); }
+      nav { width: 100%; flex-direction: row; position: sticky; top: 60px; z-index: 9; overflow-x: auto; background: var(--bg); border-bottom: 1px solid rgba(0,99,65,.25); }
       nav button { white-space: nowrap; }
       main { flex-direction: column; }
     }
@@ -291,7 +291,7 @@
       <div class="card">
         <h2>⚙️ Edita tu información</h2>
         <p class="muted">Actualiza tus datos para mantener a la red informada y conectada.</p>
-        
+
         <div class="row" style="margin-top:20px; margin-bottom: 10px;">
           <div class="avatar" id="avatarPreview" style="width: 80px; height: 80px; font-size: 24px;">🧑</div>
           <div>
@@ -305,12 +305,12 @@
           <label>Nombre completo</label><input id="fNombre" placeholder="Tu nombre completo">
           <label>Matrícula</label><input id="fMatricula" placeholder="Ej. 12345678" inputmode="numeric">
           <label>Teléfono</label><input id="fTelefono" placeholder="Ej. 5532120000">
-          
+
           <label style="display:flex;align-items:center;gap:8px; cursor: pointer;">
             <input type="checkbox" id="fTelefonoPublico" style="width: 16px; height: 16px;">
             <span>Mostrar mi número de teléfono a otros miembros</span>
           </label>
-          
+
           <label>Fecha de cumpleaños</label><input id="fCumple" type="date">
           <label>Categoría</label><input id="fCategoria" placeholder="Ej. Enfermera General A">
 
@@ -345,7 +345,7 @@
 
           <label>Biografía corta</label><textarea id="fBio" placeholder="Cuéntanos algo breve sobre ti"></textarea>
           <label>Servicios / habilidades que ofreces</label><textarea id="fServicios" placeholder="Ej. Asesoría jurídica, diseño gráfico, etc."></textarea>
-          
+
           <button class="btn" type="submit" style="justify-self: start;">💾 Guardar cambios</button>
           <div class="status meta" id="status"></div>
         </form>
@@ -473,7 +473,7 @@
         const { data: prof, error } = await supabaseClient.from('profiles')
           .select('display_name, avatar_url, categoria, adscripcion, bio, cumple, telefono, telefono_publico, servicios, matricula, role')
           .eq('user_id', CURRENT_USER.id).maybeSingle();
-        
+
         if (error) diag("Error leyendo tabla 'profiles'.", error);
 
         IS_ADMIN = (prof?.role === 'admin');
@@ -499,7 +499,7 @@
         $("pfServicios").textContent = serviciosRaw.trim() || "—";
 
         const avatar = prof?.avatar_url || md.avatar_url;
-        if (avatar) { $("userAvatar").innerHTML = `<img src="${avatar}" alt="avatar">`; $("avatarPreview").innerHTML = `<img src="${avatar}" alt="avatar">`; } 
+        if (avatar) { $("userAvatar").innerHTML = `<img src="${avatar}" alt="avatar">`; $("avatarPreview").innerHTML = `<img src="${avatar}" alt="avatar">`; }
         else { const ini = (nombreDisplay || "?")[0].toUpperCase(); $("userAvatar").textContent = ini; $("avatarPreview").textContent = ini; }
 
         $("fNombre").value = nombreDisplay || "";
@@ -638,7 +638,7 @@
                 <button class="subtle-btn btn-edit-member" data-uid="${p.user_id}">✏️ Editar</button>
               </div>
 
-              <div class="edit-member-box" data-uid="${p.user_id}" style="display:none;margin-top:14px;border-top:1px solid rgba(77,161,168,.2);padding-top:14px;">
+              <div class="edit-member-box" data-uid="${p.user_id}" style="display:none;margin-top:14px;border-top:1px solid rgba(0,99,65,.2);padding-top:14px;">
                 <div class="row" style="gap:10px;align-items:center;flex-wrap:wrap">
                   <label class="meta">Rol</label>
                   <select class="m-role">
@@ -777,7 +777,7 @@
     }
 
     function cambiarFrasePerfil() { mostrarFraseAleatoria(); }
-    
+
     async function initPerfilExtras() { aplicarValorPerfil(); await cargarFrasesPerfil(); }
   </script>
 </body>

--- a/nucleo.html
+++ b/nucleo.html
@@ -9,19 +9,19 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css" />
-  
+
   <style>
     :root {
-      --bg-body: #1b2e45; 
+      --bg-body: #004b33;
       --panel-base: 46, 79, 119;
-      --primary: #4da1a8; 
-      --primary-light: #7ad1d6;
-      --text-main: #f0fdfa; 
+      --primary: #006341;
+      --primary-light: #8fd9b6;
+      --text-main: #f0fdfa;
       --text-muted: #bce9eb;
       --danger: #ff7b7b;
-      --ring: rgba(77, 161, 168, .35);
+      --ring: rgba(0, 99, 65, .35);
     }
-    
+
     html, body {
       height: 100%;
       margin: 0;
@@ -38,9 +38,9 @@
       flex-direction: column;
       box-sizing: border-box;
     }
-    
+
     .hide { display: none !important; }
-    
+
     .status-screen {
       display: flex;
       flex-direction: column;
@@ -55,7 +55,7 @@
     .status-screen p { color: var(--text-muted); font-size: 15px; max-width: 400px; line-height: 1.4; }
     .error-icon { color: var(--danger); filter: drop-shadow(0 0 10px rgba(255,123,123,0.3)); }
     .loading-icon { color: var(--primary-light); animation: spin 2s linear infinite; }
-    
+
     .dashboard-header {
       border-bottom: 1px solid var(--ring);
       padding-bottom: 20px;
@@ -66,7 +66,7 @@
     .unidad-badge {
       display: inline-block;
       margin-top: 12px;
-      background: rgba(77, 161, 168, 0.15);
+      background: rgba(0, 99, 65, 0.15);
       border: 1px solid var(--ring);
       padding: 6px 12px;
       border-radius: 8px;
@@ -81,38 +81,38 @@
       padding: 24px;
     }
 
-    input, select, textarea { 
-      width: 100%; 
-      padding: 12px; 
-      margin-top: 8px; 
-      margin-bottom: 16px; 
-      background: rgba(0,0,0,0.2); 
-      border: 1px solid var(--ring); 
-      color: white; 
-      border-radius: 8px; 
-      font-family: 'Inter', sans-serif; 
-      box-sizing: border-box; 
+    input, select, textarea {
+      width: 100%;
+      padding: 12px;
+      margin-top: 8px;
+      margin-bottom: 16px;
+      background: rgba(0,0,0,0.2);
+      border: 1px solid var(--ring);
+      color: white;
+      border-radius: 8px;
+      font-family: 'Inter', sans-serif;
+      box-sizing: border-box;
     }
     input[type="file"] { padding: 8px; background: rgba(var(--primary), 0.1); }
-    .btn { 
-      background: linear-gradient(135deg, var(--primary), var(--primary-light)); 
-      color: #0b1f2a; 
-      font-weight: 600; 
-      padding: 12px 24px; 
-      border: none; 
-      border-radius: 8px; 
-      cursor: pointer; 
-      width: 100%; 
-      display: flex; 
-      justify-content: center; 
-      align-items: center; 
-      gap: 8px; 
+    .btn {
+      background: linear-gradient(135deg, var(--primary), var(--primary-light));
+      color: #0b1f2a;
+      font-weight: 600;
+      padding: 12px 24px;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 8px;
     }
     .btn:hover { filter: brightness(1.1); }
 
     .grid-container {
-      display: grid; 
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); 
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
       gap: 24px;
     }
 
@@ -137,14 +137,14 @@
     </div>
 
     <div class="grid-container">
-        
+
       <div class="card">
         <h3 style="margin-top: 0;"><i class="ph-duotone ph-upload-simple"></i> Subir Criterio Exitoso</h3>
         <p style="font-size: 13px; color: var(--text-muted);">Tu resolución pasará a validación por el Control Central.</p>
-        
+
         <label>Título del Conflicto</label>
         <input type="text" id="nd-titulo" placeholder="Ej. Rescisión por supuesta falta...">
-        
+
         <label>Categoría</label>
         <select id="nd-categoria">
           <option value="Sanciones">Sanciones Administrativas</option>
@@ -152,20 +152,20 @@
           <option value="Riesgos">Riesgos de Trabajo</option>
           <option value="Derechos">Derechos Contractuales</option>
         </select>
-        
+
         <label>Descripción de la Defensa</label>
         <textarea id="nd-descripcion" rows="4" placeholder="Detalla los artículos usados..."></textarea>
-        
+
         <label>Evidencia Documental (PDF)</label>
         <input type="file" id="nd-evidencia_pdf" accept="application/pdf">
-        
+
         <button class="btn" onclick="subirResolucionNucleo()">Enviar a Validación <i class="ph-bold ph-paper-plane-right"></i></button>
       </div>
 
       <div class="card">
         <h3 style="margin-top: 0;"><i class="ph-duotone ph-books"></i> Precedentes Oficiales</h3>
         <p style="font-size: 13px; color: var(--text-muted);">Criterios unificados de otras unidades (Aprobados).</p>
-        
+
         <div id="nd-lista_criterios" style="margin-top: 16px; overflow-y: auto; max-height: 500px; padding-right: 8px;">
           <p style="font-size: 13px; color: var(--text-muted);">Cargando precedentes...</p>
         </div>
@@ -195,14 +195,14 @@
         uiStatusTitle.style.color = "var(--danger)";
       }
       if (uiStatusDesc) uiStatusDesc.textContent = desc;
-      
+
       if (uiAppContainer) uiAppContainer.classList.add('hide');
       if (uiStatusContainer) uiStatusContainer.classList.remove('hide');
     }
 
     const nucleoWatchdog = setTimeout(() => {
       showNucleoError(
-        "Tiempo de espera agotado", 
+        "Tiempo de espera agotado",
         "No pudimos verificar tu sesión. Si estás viendo esto en un iframe, es posible que tu navegador esté bloqueando el acceso por motivos de seguridad."
       );
     }, 8000);
@@ -212,20 +212,20 @@
       try {
         const supabaseUrl = "https://axsncdwshdvsysrpikwj.supabase.co";
         const supabaseKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF4c25jZHdzaGR2c3lzcnBpa3dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjAyMjkwMjQsImV4cCI6MjA3NTgwNTAyNH0.oapcH219puVjaR2DcG7dX51uhwVn530L1hhz8ASv7qs";
-        
+
         // Inicializamos con nuestro propio nombre de variable
         nucleoSupabase = window.supabase.createClient(supabaseUrl, supabaseKey);
 
         console.log("[Núcleo] Iniciando validación...");
         const { data: { session }, error: sessionError } = await nucleoSupabase.auth.getSession();
-        
+
         clearTimeout(nucleoWatchdog);
 
         if (sessionError) {
           showNucleoError("Error de Autenticación", sessionError.message);
           return;
         }
-        
+
         if (!session) {
           showNucleoError("Acceso Denegado", "No se detectó una sesión activa en este módulo. Inicia sesión en la plataforma principal.");
           return;
@@ -239,11 +239,11 @@
           console.log("[Núcleo] Acceso de Administrador.");
           nucleoDelegacionId = "ADMIN";
           nucleoDelegacionNombre = "Administrador General";
-          
+
           if (uiUnidadBadge) uiUnidadBadge.innerHTML = `<i class="ph-bold ph-shield-star"></i> ${nucleoDelegacionNombre}`;
           if (uiStatusContainer) uiStatusContainer.classList.add('hide');
           if (uiAppContainer) uiAppContainer.classList.remove('hide');
-          
+
           cargarPrecedentesNucleo();
           return;
         }
@@ -272,7 +272,7 @@
           showNucleoError("Privilegios Insuficientes", "Tu cuenta no está registrada como representación autorizada.");
           return;
         }
-        
+
         nucleoDelegacionId = userID;
         nucleoDelegacionNombre = authData.nombre_unidad;
 
@@ -352,7 +352,7 @@
           .order('fecha_creacion', { ascending: false });
 
         const lista = document.getElementById('nd-lista_criterios');
-        lista.innerHTML = ''; 
+        lista.innerHTML = '';
 
         if (error) {
           lista.innerHTML = '<p style="font-size: 13px; color: #ff6b6b;">Error al cargar los datos.</p>';
@@ -371,7 +371,7 @@
             <strong style="color: var(--primary-light);">${resolucion.nombre_delegacion}</strong><br>
             <span style="font-size: 14px; color: var(--text-main); font-weight: 600;">${resolucion.titulo_conflicto}</span><br>
             <span style="font-size: 12px; color: var(--text-muted); display: block; margin: 4px 0;">${resolucion.descripcion}</span>
-            <span style="display: inline-block; background: rgba(77,161,168,0.2); color: var(--primary-light); padding: 2px 6px; border-radius: 4px; font-size: 10px; margin-bottom: 8px;">${resolucion.categoria}</span><br>
+            <span style="display: inline-block; background: rgba(0,99,65,0.2); color: var(--primary-light); padding: 2px 6px; border-radius: 4px; font-size: 10px; margin-bottom: 8px;">${resolucion.categoria}</span><br>
             <a href="${resolucion.pdf_url}" target="_blank" style="color: var(--primary); font-size: 12px; text-decoration: none; font-weight: 600;">
               <i class="ph-bold ph-file-pdf"></i> Ver Documento
             </a>

--- a/perfil.html
+++ b/perfil.html
@@ -9,13 +9,13 @@
     href="https://raw.githubusercontent.com/ChronosBVRX/PlataformaComunitaria/refs/heads/main/Logo%20PSC.jpeg">
   <style>
     :root {
-      --bg: #1b2e45;
+      --bg: #004b33;
       --panel: #2e4f77;
-      --ring: rgba(77, 161, 168, .45);
+      --ring: rgba(0, 99, 65, .45);
       --txt: #f0fdfa;
       --muted: #bce9eb;
-      --primary: #4da1a8;
-      --sky: #7ad1d6;
+      --primary: #006341;
+      --sky: #8fd9b6;
     }
 
     * {
@@ -27,7 +27,7 @@
 
     body {
       min-height: 100vh;
-      background: linear-gradient(180deg, #152336, #1b2e45);
+      background: linear-gradient(180deg, #003423, #004b33);
       color: var(--txt);
       display: flex;
       flex-direction: column
@@ -43,7 +43,7 @@
       padding: 10px 16px;
       background: rgba(30, 50, 80, .75);
       backdrop-filter: blur(8px);
-      border-bottom: 1px solid rgba(77, 161, 168, .35)
+      border-bottom: 1px solid rgba(0, 99, 65, .35)
     }
 
     header img {
@@ -81,7 +81,7 @@
     nav {
       width: 240px;
       background: rgba(27, 46, 69, .85);
-      border-right: 1px solid rgba(77, 161, 168, .25);
+      border-right: 1px solid rgba(0, 99, 65, .25);
       padding: 12px;
       display: flex;
       flex-direction: column;
@@ -91,7 +91,7 @@
     nav button {
       appearance: none;
       border: none;
-      background: rgba(77, 161, 168, .12);
+      background: rgba(0, 99, 65, .12);
       color: var(--txt);
       padding: 10px;
       border-radius: 10px;
@@ -120,7 +120,7 @@
 
     .card {
       background: var(--panel);
-      border: 1px solid rgba(77, 161, 168, .35);
+      border: 1px solid rgba(0, 99, 65, .35);
       border-radius: 16px;
       padding: 20px;
       box-shadow: 0 8px 25px rgba(0, 0, 0, .25);
@@ -193,8 +193,8 @@
     input,
     textarea,
     select {
-      background: #1b2e45;
-      border: 1px solid rgba(77, 161, 168, .4);
+      background: #004b33;
+      border: 1px solid rgba(0, 99, 65, .4);
       color: #f0fdfa;
       padding: 9px 11px;
       border-radius: 10px
@@ -224,8 +224,8 @@
 
     .subtle-btn {
       appearance: none;
-      border: 1px solid rgba(77, 161, 168, .28);
-      background: rgba(77, 161, 168, .1);
+      border: 1px solid rgba(0, 99, 65, .28);
+      background: rgba(0, 99, 65, .1);
       color: #fff;
       padding: 6px 10px;
       border-radius: 10px;
@@ -234,7 +234,7 @@
     }
 
     .subtle-btn:hover {
-      background: rgba(77, 161, 168, .25)
+      background: rgba(0, 99, 65, .25)
     }
 
     .meta {
@@ -255,8 +255,8 @@
       gap: 6px;
       padding: 4px 8px;
       border-radius: 999px;
-      background: rgba(77, 161, 168, .15);
-      border: 1px solid rgba(77, 161, 168, .35);
+      background: rgba(0, 99, 65, .15);
+      border: 1px solid rgba(0, 99, 65, .35);
       font-size: 12px;
       color: #d1f5f7
     }
@@ -281,14 +281,14 @@
       gap: 10px;
       padding: 10px 12px;
       border-radius: 12px;
-      background: rgba(77, 161, 168, .15);
-      border: 1px solid rgba(77, 161, 168, .28);
+      background: rgba(0, 99, 65, .15);
+      border: 1px solid rgba(0, 99, 65, .28);
       font-weight: 600;
       color: #d1f5f7
     }
 
     details.forum-toggle[open]>summary {
-      background: rgba(77, 161, 168, .25)
+      background: rgba(0, 99, 65, .25)
     }
 
     details.forum-toggle>summary::-webkit-details-marker {
@@ -307,7 +307,7 @@
       display: grid;
       place-items: center;
       background: rgba(255, 255, 255, .05);
-      border: 1px solid rgba(77, 161, 168, .25);
+      border: 1px solid rgba(0, 99, 65, .25);
       border-radius: 12px;
       padding: 12px;
       width: 220px
@@ -367,7 +367,7 @@
 
     .perfil-extra-card {
       background: #233b5c;
-      border: 1px solid rgba(77, 161, 168, .35);
+      border: 1px solid rgba(0, 99, 65, .35);
       border-radius: 12px;
       padding: 10px 12px;
     }
@@ -398,14 +398,14 @@
       font-size: 12px;
       padding: 5px 10px;
       border-radius: 999px;
-      border: 1px solid rgba(77, 161, 168, .6);
+      border: 1px solid rgba(0, 99, 65, .6);
       background: rgba(21, 35, 54, 0.9);
       color: #f0fdfa;
       cursor: pointer;
     }
 
     .btn-mini:hover {
-      background: rgba(77, 161, 168, .25);
+      background: rgba(0, 99, 65, .25);
     }
 
     #perfilValorList,
@@ -466,7 +466,7 @@
       padding: 12px;
       border: 1px dashed var(--sky);
       border-radius: 12px;
-      background: rgba(122, 209, 214, 0.05);
+      background: rgba(143, 217, 182, 0.05);
     }
 
     .blur-box {
@@ -747,7 +747,7 @@
           style="width:100%;min-height:650px;border:0;border-radius:12px;margin-top:12px" loading="lazy"></iframe>
       </div>
     </section>
-    
+
     <section id="comite" class="content">
       <div class="card">
         <h2>🏛️ Gestión del Comité Seccional</h2>
@@ -1092,13 +1092,13 @@
       if (!IS_ADMIN) return;
       const wrap = $("comiteList");
       if (!wrap) return;
-      
+
       wrap.innerHTML = '<div class="meta">Cargando estructura del comité...</div>';
 
       const { data, error } = await supabaseClient
         .from('comite')
         .select('*')
-        .order('id', { ascending: true }); 
+        .order('id', { ascending: true });
 
       if (error) {
         wrap.innerHTML = '<div class="meta">❌ Error cargando comité.</div>';
@@ -1113,7 +1113,7 @@
       const wrap = $("comiteList");
       if (!wrap) return;
       wrap.innerHTML = '';
-      
+
       if (!COMITE_CACHE.length) {
         wrap.innerHTML = '<div class="meta">No hay carteras registradas en la base de datos.</div>';
         return;
@@ -1122,27 +1122,27 @@
       COMITE_CACHE.forEach(item => {
         const card = document.createElement('div');
         card.className = 'card';
-        const fotoHtml = item.foto 
-          ? `<img src="${item.foto}" style="width:100%;height:100%;object-fit:cover;border-radius:50%">` 
+        const fotoHtml = item.foto
+          ? `<img src="${item.foto}" style="width:100%;height:100%;object-fit:cover;border-radius:50%">`
           : `🧑`;
 
         card.innerHTML = `
           <div class="row" style="align-items:flex-start">
-            <div class="avatar" style="width:64px;height:64px;background:#152336">${fotoHtml}</div>
+            <div class="avatar" style="width:64px;height:64px;background:#003423">${fotoHtml}</div>
             <div style="flex:1;min-width:220px">
               <div style="font-weight:800; color:var(--sky)">${escapeHtml(item.cartera)}</div>
               <div class="meta">${escapeHtml(item.area)}</div>
-              
+
               <div class="meta" style="margin-top:6px">👤 ${escapeHtml(item.nombre || 'Vacante')}</div>
               <div class="meta">🪪 ${escapeHtml(item.categoria || 'Sin categoría')}</div>
               <div class="meta">🏥 ${escapeHtml(item.unidad || 'Sin unidad')}</div>
 
               <button class="subtle-btn btn-edit-comite" data-id="${item.id}" style="margin-top:10px">✏️ Editar Candidato</button>
 
-              <div class="edit-comite-box" data-id="${item.id}" style="display:none;margin-top:10px;background:rgba(0,0,0,0.15);padding:12px;border-radius:8px;border:1px solid rgba(77, 161, 168, .35)">
+              <div class="edit-comite-box" data-id="${item.id}" style="display:none;margin-top:10px;background:rgba(0,0,0,0.15);padding:12px;border-radius:8px;border:1px solid rgba(0, 99, 65, .35)">
                 <label style="display:block;margin-bottom:4px;font-size:12px;color:var(--muted)">Foto del Candidato (PNG/JPG):</label>
                 <input type="file" class="c-foto" accept="image/png,image/jpeg,image/webp" style="width:100%;margin-bottom:10px">
-                
+
                 <input class="c-nombre" placeholder="Nombre completo" value="${escapeHtml(item.nombre || '')}" style="width:100%;margin-bottom:8px">
                 <input class="c-cat" placeholder="Categoría (Ej. Médico No Familiar)" value="${escapeHtml(item.categoria || '')}" style="width:100%;margin-bottom:8px">
                 <input class="c-uni" placeholder="Adscripción (Ej. HGZ 83)" value="${escapeHtml(item.unidad || '')}" style="width:100%;margin-bottom:10px">
@@ -1569,7 +1569,7 @@
 
       wrap.querySelectorAll('.btn-edit').forEach(btn => btn.addEventListener('click', (e) => {
         e.preventDefault(); e.stopPropagation(); const card = btn.closest('.card'); const contentEl = card.querySelector('.post-content');
-        contentEl.outerHTML = `<div class="edit-wrap" style="margin-top:8px;display:grid;gap:8px"><textarea class="edit-textarea" style="min-height:120px;background:#1b2e45;border:1px solid rgba(77, 161, 168, .3);color:#f0fdfa;padding:9px 11px;border-radius:10px">${contentEl.textContent}</textarea><div class="row"><button class="btn btn-save-edit" data-id="${btn.dataset.id}">💾 Guardar</button><button class="subtle-btn btn-cancel-edit">Cancelar</button></div></div>`;
+        contentEl.outerHTML = `<div class="edit-wrap" style="margin-top:8px;display:grid;gap:8px"><textarea class="edit-textarea" style="min-height:120px;background:#004b33;border:1px solid rgba(0, 99, 65, .3);color:#f0fdfa;padding:9px 11px;border-radius:10px">${contentEl.textContent}</textarea><div class="row"><button class="btn btn-save-edit" data-id="${btn.dataset.id}">💾 Guardar</button><button class="subtle-btn btn-cancel-edit">Cancelar</button></div></div>`;
         card.querySelector('.btn-cancel-edit').addEventListener('click', () => loadPostsDeb());
         card.querySelector('.btn-save-edit').addEventListener('click', async () => {
           const newText = (card.querySelector('.edit-textarea').value || '').trim();

--- a/planillas.html
+++ b/planillas.html
@@ -24,7 +24,7 @@
         }
 
         h1 { color: #122c4d; text-align: center; }
-        
+
         .form-group {
             margin-bottom: 20px;
             background: #f8f9fa;
@@ -72,15 +72,15 @@
 
         /* --- ENCABEZADO Y LOGOS --- */
         .p-header { text-align: center; padding-top: 0.6in; padding-bottom: 0.1in; }
-        
+
         .p-logo-container {
             display: inline-flex; flex-direction: column; align-items: center; margin-bottom: 0.1in;
         }
 
         .p-logo-circular {
-            width: 2.2in; height: 2.2in; border-radius: 50%; object-fit: contain; 
-            border: 0.05in solid var(--dark-blue); background-color: white; 
-            margin: 0; padding: 0.1in; 
+            width: 2.2in; height: 2.2in; border-radius: 50%; object-fit: contain;
+            border: 0.05in solid var(--dark-blue); background-color: white;
+            margin: 0; padding: 0.1in;
         }
 
         .p-header h1 { color: var(--dark-blue); font-size: 0.55in; font-weight: 900; margin-top: 0.1in; margin-bottom: 0.05in; text-transform: uppercase; }
@@ -109,7 +109,7 @@
             margin: 0.1in auto 0.2in auto; border-radius: 100px; display: flex; align-items: center; position: relative;
         }
         .p-rep-photo {
-            width: 2.2in; height: 2.2in; background-color: #ccc; border-radius: 50%; 
+            width: 2.2in; height: 2.2in; background-color: #ccc; border-radius: 50%;
             border: 0.08in solid var(--dark-blue); position: absolute; left: -0.5in; object-fit: cover;
         }
         .p-rep-info { margin-left: 2in; display: flex; flex-direction: column; justify-content: center; }
@@ -117,16 +117,16 @@
         .p-rep-name { font-size: 0.32in; font-weight: 900; text-transform: uppercase; margin-bottom: 0.02in;}
         .p-rep-role { font-size: 0.20in; text-transform: uppercase; color: #ddd;}
         .p-rep-unit { font-size: 0.20in; font-weight: bold; color: var(--teal); text-transform: uppercase; }
-        
+
         .p-logo-sec {
             position: absolute; right: 0.5in; width: 1.2in; height: 1.2in; border-radius: 50%;
             object-fit: contain; border: 0.03in solid white; background-color: white; padding: 0.05in;
         }
 
         /* --- CUADRÍCULA DINÁMICA CON INTEGRANTES --- */
-        .p-grid { 
-            display: grid; padding: 0 0.5in; margin-top: 0.1in; flex-grow: 1; 
-            align-content: start; 
+        .p-grid {
+            display: grid; padding: 0 0.5in; margin-top: 0.1in; flex-grow: 1;
+            align-content: start;
         }
         .p-card { background: white; display: flex; align-items: center; box-sizing: border-box; }
         .p-card-photo { background-color: #ccc; object-fit: cover; }
@@ -178,7 +178,7 @@
 
     <div class="app-container" id="form-section">
         <h1>Generador de Equipos - Alta Resolución</h1>
-        
+
         <div class="form-group">
             <h3>Información Electoral</h3>
             <label>Unidad Electoral:</label>
@@ -259,7 +259,7 @@
         function generarCamposIntegrantes() {
             const container = document.getElementById('integrantes-container');
             const num = document.getElementById('numIntegrantes').value;
-            container.innerHTML = ''; 
+            container.innerHTML = '';
 
             for (let i = 1; i <= num; i++) {
                 container.innerHTML += `
@@ -299,8 +299,8 @@
 
             const num = parseInt(document.getElementById('numIntegrantes').value);
             const grid = document.getElementById('render-grid');
-            grid.innerHTML = ''; 
-            
+            grid.innerHTML = '';
+
             grid.className = 'p-grid';
             if (num >= 10 && num <= 15) {
                 grid.classList.add('size-md');
@@ -314,9 +314,9 @@
                 let nombre = document.getElementById(`nombreInt${i}`).value || 'NOMBRE DEL INTEGRANTE';
                 let cargo = document.getElementById(`cargoInt${i}`).value || 'CARGO';
                 let unidad = document.getElementById(`unidadInt${i}`).value || 'UNIDAD';
-                
+
                 let fotoInput = document.getElementById(`fotoInt${i}`);
-                let fotoSrc = pixelGris; 
+                let fotoSrc = pixelGris;
                 if(fotoInput.files && fotoInput.files[0]) {
                     fotoSrc = URL.createObjectURL(fotoInput.files[0]);
                 }
@@ -343,9 +343,9 @@
             const poster = document.getElementById('poster-section');
             const options = {
                 scale: 3,
-                useCORS: true, 
+                useCORS: true,
                 allowTaint: true,
-                backgroundColor: '#f6f8f9', 
+                backgroundColor: '#f6f8f9',
                 width: poster.offsetWidth,
                 height: poster.offsetHeight,
                 onclone: (clonedDoc) => {
@@ -364,7 +364,7 @@
                 link.href = image;
                 link.download = 'equipo_congresional_alta_resolucion.png';
                 link.click();
-                
+
                 btn.innerHTML = textoOriginal;
                 btn.disabled = false;
             }).catch(err => {

--- a/prestaciones.html
+++ b/prestaciones.html
@@ -6,18 +6,18 @@
   <title>Plataforma Comunitaria CG — Calculadoras CCT</title>
   <style>
     :root {
-      --bg: #0f172a;         
-      --card: #1e293b;       
-      --input: #334155;      
-      --txt: #f1f5f9;        
-      --muted: #94a3b8;      
-      --primary: #2dd4bf;    
-      --primary-dark: #14b8a6; 
-      --accent: #facc15;     
-      --danger: #fb7185;     
+      --bg: #0f172a;
+      --card: #1e293b;
+      --input: #334155;
+      --txt: #f1f5f9;
+      --muted: #94a3b8;
+      --primary: #00a86b;
+      --primary-dark: #007a50;
+      --accent: #facc15;
+      --danger: #fb7185;
       --border: rgba(255, 255, 255, 0.1);
       --shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
-      
+
       --cpto-bg: rgba(45, 212, 191, 0.15);
       --cpto-danger-bg: rgba(251, 113, 133, 0.15);
       --warning-bg: rgba(250, 204, 21, 0.05);
@@ -38,11 +38,11 @@
     .autocomplete-wrapper { position: relative; }
     input[type="text"], input[type="number"], select { width: 100%; padding: 14px; border: 1px solid var(--border); border-radius: 10px; font-size: 1rem; outline: none; transition: border-color 0.2s; background-color: var(--input); color: var(--txt);}
     input:focus, select:focus { border-color: var(--primary); }
-    
+
     .autocomplete-items { position: absolute; border: 1px solid var(--border); border-top: none; z-index: 99; top: 100%; left: 0; right: 0; max-height: 250px; overflow-y: auto; background: var(--card); border-radius: 0 0 10px 10px; box-shadow: var(--shadow); margin-top: 4px;}
     .autocomplete-items div { padding: 14px; cursor: pointer; border-bottom: 1px solid var(--border); font-size: 0.95rem; display: flex; justify-content: space-between; align-items: center;}
     .autocomplete-items div:hover { background-color: rgba(45, 212, 191, 0.1); color: var(--txt); }
-    
+
     .user-data-bar { display: none; margin-top: 20px; padding: 16px; background: rgba(0,0,0,0.2); border-radius: 10px; border-left: 4px solid var(--primary); font-size: 0.95rem; align-items: center; border: 1px solid var(--border);}
     .user-data-bar.active { display: flex; gap: 24px; flex-wrap: wrap; }
     .user-data-bar span { font-weight: 700; color: var(--txt); font-size: 1.05rem;}
@@ -59,7 +59,7 @@
     .panel { background: var(--card); border-radius: 16px; padding: 24px; box-shadow: var(--shadow); display: none; animation: fadeIn 0.3s ease; }
     .panel.active { display: block; }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
-    
+
     .panel h2 { color: var(--primary); margin-bottom: 12px; font-size: 1.5rem; font-weight: 700;}
     .panel p.desc { color: var(--muted); margin-bottom: 24px; font-size: 1rem; line-height: 1.5; }
 
@@ -74,7 +74,7 @@
     .result-row:last-child { border-bottom: none; }
     .result-label { font-size: 0.95rem; color: var(--muted); }
     .result-value { font-family: monospace; font-size: 1.2rem; font-weight: 700; color: var(--txt); text-align: right;}
-    
+
     .cpto-tag { background: var(--cpto-bg); color: var(--primary); padding: 4px 8px; border-radius: 6px; font-size: 0.75rem; font-weight: 800; margin-left: 8px; display: inline-flex; align-items: center; border: 1px solid rgba(45, 212, 191, 0.3);}
     .cpto-tag.desc { background: var(--cpto-danger-bg); color: var(--danger); border-color: rgba(251, 113, 133, 0.3);}
 
@@ -106,7 +106,7 @@
     <div class="autocomplete-wrapper">
       <input type="text" id="buscador" placeholder="Escribe aquí tu puesto (Ej. Enfermera General, Medico, Auxiliar...)" autocomplete="off">
     </div>
-    
+
     <div id="user-data" class="user-data-bar">
       <div>
         <span style="color:var(--muted); font-weight:normal; font-size:0.85rem;">Categoría</span><br>
@@ -143,11 +143,11 @@
     </nav>
 
     <main>
-      
+
       <div id="p-anticipo" class="panel active">
         <h2>Anticipo de Sueldo</h2>
         <p class="desc">Descubre cuánto puedes pedir de adelanto de tu sueldo para salir de un apuro y en cuánto te quedará el descuento a la quincena. ¡Cero intereses!</p>
-        
+
         <div class="form-group">
           <label>¿Cuántos meses necesitas que te adelanten?</label>
           <select id="ant_meses">
@@ -182,7 +182,7 @@
       <div id="p-ahorro" class="panel">
         <h2>Fondo de Ahorro (La 2da de Julio)</h2>
         <p class="desc">Calcula ese guardadito anual que cae como anillo al dedo en la segunda quincena de julio.</p>
-        
+
         <div class="form-group">
           <label>¿Cuántos días laboraste en el último año? (De julio a julio)</label>
           <input type="number" id="aho_dias" value="365" max="365">
@@ -209,7 +209,7 @@
       <div id="p-extra" class="panel">
         <h2>Pago de Tiempo Extra</h2>
         <p class="desc">Conoce exactamente cuánto te pagarán por esas horas adicionales que te quedaste apoyando en tu servicio.</p>
-        
+
         <div class="form-group">
           <label>¿Cuántas horas extra laboraste en la quincena?</label>
           <input type="number" id="ext_horas" placeholder="Ej. 4">
@@ -243,7 +243,7 @@
       <div id="p-hipo-largo" class="panel">
         <h2>Crédito Hipotecario a Largo Plazo</h2>
         <p class="desc">Mira cuánto te presta el Instituto para comprar, construir o reparar tu casa, y en cuánto te quedaría el descuento a 30 años.</p>
-        
+
         <div class="form-group">
           <label>¿Qué tan libre de deudas está tu tarjetón de pago?</label>
           <select id="hl_liq">
@@ -276,7 +276,7 @@
       <div id="p-hipo-medio" class="panel">
         <h2>Crédito Hipotecario a Mediano Plazo</h2>
         <p class="desc">Una excelente opción si quieres un préstamo para tu vivienda que liquides mucho más rápido (máximo en 12 años).</p>
-        
+
         <button class="btn-calc" onclick="calcHipoMedio()">Simular mi Crédito a 12 años</button>
 
         <div id="res_hipo_medio" class="result-card">
@@ -302,7 +302,7 @@
       <div id="p-auto" class="panel">
         <h2>Crédito de Automóvil</h2>
         <p class="desc">Descubre de cuánto es tu crédito para estrenar auto, pagándolo cómodamente en 5 años (120 quincenas).</p>
-        
+
         <button class="btn-calc" onclick="calcAuto()">Simular mi Crédito Automotriz</button>
 
         <div id="res_auto" class="result-card">
@@ -335,7 +335,7 @@
       <div id="p-aguinaldo" class="panel">
         <h2>Aguinaldo y Anticipos</h2>
         <p class="desc">El aguinaldo total equivale a 3 meses de sueldo. Conoce tus adelantos y el saldo libre de impuestos que recibirás en diciembre.</p>
-        
+
         <div class="form-group">
           <label>¿Pediste que te adelantaran un mes de aguinaldo en Agosto?</label>
           <select id="ag_agosto">
@@ -378,24 +378,24 @@
   // UTILIDADES Y VARIABLES INTERNAS
   // -------------------------------------------------------------
   const money = n => n.toLocaleString('es-MX', {style:'currency', currency:'MXN'});
-  
-  // Guardamos los datos puros para la matemática. 
-  // 'tabular_mensual' es el de la BD. 
+
+  // Guardamos los datos puros para la matemática.
+  // 'tabular_mensual' es el de la BD.
   // 'renta_quincenal' es el que ingresa el usuario en pantalla.
-  let userData = { 
-      tabular_mensual: 0, 
-      renta_quincenal: 0, 
-      jornada: 8, 
-      categoria: '' 
+  let userData = {
+      tabular_mensual: 0,
+      renta_quincenal: 0,
+      jornada: 8,
+      categoria: ''
   };
-  
+
   // Normalizar acentos para la búsqueda
   const removeAccents = (str) => {
     return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   };
-  
+
   // -------------------------------------------------------------
-  // BASE DE DATOS COMPLETA 
+  // BASE DE DATOS COMPLETA
   // -------------------------------------------------------------
   const sueldosDB = [{"cat": "Pasante de Abogado", "jor": "6.5", "sm": 5097.96}, {"cat": "Abogado", "jor": "6.5", "sm": 9125.04}, {"cat": "Abogado", "jor": "8.0", "sm": 11230.64}, {"cat": "Auxiliar Técnico de Actuariado Social", "jor": "6.5", "sm": 7553.14}, {"cat": "Oficial Técnico de Actuariado Social", "jor": "6.5", "sm": 8345.36}, {"cat": "Técnico de Actuariado Social", "jor": "6.5", "sm": 8932.24}, {"cat": "Actuario Social Matemático", "jor": "6.5", "sm": 9581.5}, {"cat": "Auxiliar de Servicios Administrativos", "jor": "6.5", "sm": 3302.5}, {"cat": "Auxiliar de Servicios Administrativos", "jor": "8.0", "sm": 4064.76}, {"cat": "Ayudante de Cajero B", "jor": "8.0", "sm": 5022.12}, {"cat": "Ayudante de Cajero A", "jor": "8.0", "sm": 5330.68}, {"cat": "Cajero D", "jor": "6.5", "sm": 5351.94}, {"cat": "Cajero D", "jor": "8.0", "sm": 6587.36}, {"cat": "Cajero C", "jor": "8.0", "sm": 6999.44}, {"cat": "Cajero B", "jor": "6.5", "sm": 6084.36}, {"cat": "Cajero A", "jor": "8.0", "sm": 7656.68}, {"cat": "Contador", "jor": "6.5", "sm": 9125.04}, {"cat": "Contador", "jor": "8.0", "sm": 11230.64}, {"cat": "Contador Auditor", "jor": "6.5", "sm": 9125.04}, {"cat": "Contador Auditor", "jor": "8.0", "sm": 11230.64}, {"cat": "Pasante de Economista", "jor": "8.0", "sm": 5876.44}, {"cat": "Economista", "jor": "6.5", "sm": 9125.04}, {"cat": "Economista", "jor": "8.0", "sm": 11230.64}, {"cat": "Sociólogo", "jor": "6.5", "sm": 9125.04}, {"cat": "Redactor B", "jor": "6.5", "sm": 4583.28}, {"cat": "Mensajero", "jor": "6.5", "sm": 3955.4}, {"cat": "Mensajero", "jor": "8.0", "sm": 4868.04}, {"cat": "Auxiliar Universal de Oficinas", "jor": "6.5", "sm": 4746.16}, {"cat": "Auxiliar Universal de Oficinas", "jor": "8.0", "sm": 5841.44}, {"cat": "Auxiliar de Soporte Técnico en Informática", "jor": "8.0", "sm": 8340.48}, {"cat": "Oficial de Soporte Técnico en Informática", "jor": "8.0", "sm": 10242.12}, {"cat": "Coordinador de Soporte Técnico en Informática", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Tesorería", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Tesorería", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Tesorería", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Tesorería", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Servicios Técnicos", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Servicios Técnicos", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Servicios Técnicos", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Servicios Técnicos", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Servicios Administrativos", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Servicios Administrativos", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Servicios Administrativos", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Servicios Administrativos", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Personal", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Personal", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Personal", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Personal", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Estadística", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Estadística", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Estadística", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Estadística", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Procesamiento de Datos", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Procesamiento de Datos", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Procesamiento de Datos", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Procesamiento de Datos", "jor": "8.0", "sm": 11266.48}, {"cat": "Oficial de Contabilidad", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Contabilidad", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Contabilidad", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Contabilidad", "jor": "8.0", "sm": 11266.48}, {"cat": "Jefe de Oficina A", "jor": "8.0", "sm": 11266.48}, {"cat": "Jefe Técnico de Cobranzas y Adeudos", "jor": "8.0", "sm": 11266.48}, {"cat": "Médico General", "jor": "8.0", "sm": 9751.8}, {"cat": "Médico Familiar", "jor": "8.0", "sm": 12844.2}, {"cat": "Médico No Familiar", "jor": "8.0", "sm": 12844.2}, {"cat": "Cirujano Máxilo Facial", "jor": "8.0", "sm": 12844.2}, {"cat": "Estomatólogo", "jor": "8.0", "sm": 11924.12}, {"cat": "Ortopedista", "jor": "8.0", "sm": 7875.28}, {"cat": "Partera", "jor": "6.5", "sm": 6837.68}, {"cat": "Partera", "jor": "8.0", "sm": 8415.48}, {"cat": "Jefe de Parteras", "jor": "6.5", "sm": 7350.52}, {"cat": "Jefe de Parteras", "jor": "8.0", "sm": 9046.64}, {"cat": "Veterinario", "jor": "6.5", "sm": 9125.04}, {"cat": "Veterinario", "jor": "8.0", "sm": 11230.64}, {"cat": "Auxiliar de Enfermería General", "jor": "8.0", "sm": 6108.68}, {"cat": "Auxiliar de Enfermería en Salud Pública", "jor": "8.0", "sm": 6108.68}, {"cat": "Enfermera General", "jor": "8.0", "sm": 7381.12}, {"cat": "Enfermera General Clínica (EGC)", "jor": "8.0", "sm": 7898.3}, {"cat": "Enfermera Especialista", "jor": "8.0", "sm": 8415.48}, {"cat": "Enfermera Jefe de Piso", "jor": "8.0", "sm": 10242.12}, {"cat": "Asistente Médica", "jor": "6.5", "sm": 4963.16}, {"cat": "Asistente Médica", "jor": "8.0", "sm": 6108.68}, {"cat": "Coordinadora de Asistentes Médicas", "jor": "8.0", "sm": 6767.2}, {"cat": "Persona usuariaa Social", "jor": "6.5", "sm": 5897.4}, {"cat": "Persona usuariaa Social", "jor": "8.0", "sm": 7258.16}, {"cat": "Persona usuaria Social Clínico", "jor": "8.0", "sm": 8274.84}, {"cat": "Auxiliar de Trabajo Social", "jor": "6.5", "sm": 4667.16}, {"cat": "Auxiliar de Trabajo Social", "jor": "8.0", "sm": 5744.26}, {"cat": "Nutricionista Dietista", "jor": "6.5", "sm": 5897.4}, {"cat": "Nutricionista Dietista", "jor": "8.0", "sm": 7258.16}, {"cat": "Especialista en Nutrición y Dietética", "jor": "8.0", "sm": 8415.48}, {"cat": "Nutriólogo Clínico Especializado", "jor": "8.0", "sm": 10242.12}, {"cat": "Auxiliar de Técnico en Servicios de Dietología", "jor": "6.5", "sm": 5160.52}, {"cat": "Auxiliar de Técnico en Servicios de Dietología", "jor": "8.0", "sm": 6351.46}, {"cat": "Auxiliar de Administración en Unidad Médica (Polivalente)", "jor": "6.5", "sm": 4808.42}, {"cat": "Auxiliar de Administración en Unidad Médica (Polivalente)", "jor": "8.0", "sm": 5917.9}, {"cat": "Auxiliar de Enfermería en Unidad Médica (Polivalente)", "jor": "6.5", "sm": 4924.46}, {"cat": "Auxiliar de Enfermería en Unidad Médica (Polivalente)", "jor": "8.0", "sm": 6060.88}, {"cat": "Técnico Radiólogo", "jor": "6.0", "sm": 5906.46}, {"cat": "Técnico Radiólogo", "jor": "8.0", "sm": 7875.28}, {"cat": "Radioterapeuta", "jor": "6.0", "sm": 5906.46}, {"cat": "Radioterapeuta", "jor": "8.0", "sm": 7875.28}, {"cat": "Laboratorista", "jor": "6.0", "sm": 6212.9}, {"cat": "Laboratorista", "jor": "8.0", "sm": 8283.66}, {"cat": "Auxiliar de Laboratorio", "jor": "6.0", "sm": 4732.06}, {"cat": "Auxiliar de Laboratorio", "jor": "8.0", "sm": 6309.58}, {"cat": "Químico Clínico", "jor": "8.0", "sm": 11230.64}, {"cat": "Químico Clínico Jefe de Sección", "jor": "8.0", "sm": 11793.36}, {"cat": "Citotecnólogo", "jor": "8.0", "sm": 7875.28}, {"cat": "Histotecnólogo", "jor": "6.0", "sm": 5906.46}, {"cat": "Histotecnólogo", "jor": "8.0", "sm": 7875.28}, {"cat": "Inhaloterapeuta", "jor": "6.0", "sm": 5906.46}, {"cat": "Inhaloterapeuta", "jor": "6.5", "sm": 6398.64}, {"cat": "Inhaloterapeuta", "jor": "8.0", "sm": 7875.28}, {"cat": "Electrocardiografista", "jor": "8.0", "sm": 7279.54}, {"cat": "Fonoaudiólogo", "jor": "6.0", "sm": 5906.46}, {"cat": "Fonoaudiólogo", "jor": "8.0", "sm": 7875.28}, {"cat": "Optometrista", "jor": "6.0", "sm": 5906.46}, {"cat": "Optometrista", "jor": "8.0", "sm": 7875.28}, {"cat": "Psicólogo", "jor": "8.0", "sm": 11230.64}, {"cat": "Psicólogo Clínico", "jor": "6.0", "sm": 8422.92}, {"cat": "Psicólogo Clínico", "jor": "8.0", "sm": 11230.64}, {"cat": "Psicómetra", "jor": "6.0", "sm": 5906.46}, {"cat": "Psicómetra", "jor": "8.0", "sm": 7875.28}, {"cat": "Técnico en Anestesia", "jor": "6.0", "sm": 6497.8}, {"cat": "Técnico en Anestesia", "jor": "8.0", "sm": 8663.78}, {"cat": "Técnico en Manejo de Aparatos de Electrodiagnóstico", "jor": "6.0", "sm": 5459.64}, {"cat": "Técnico en Manejo de Aparatos de Electrodiagnóstico", "jor": "8.0", "sm": 7279.54}, {"cat": "Técnico en Medicina Nuclear", "jor": "8.0", "sm": 7875.28}, {"cat": "Terapista Físico", "jor": "6.0", "sm": 5906.46}, {"cat": "Terapista Físico", "jor": "8.0", "sm": 7875.28}, {"cat": "Terapista Ocupacional", "jor": "6.0", "sm": 5906.46}, {"cat": "Terapista Ocupacional", "jor": "8.0", "sm": 7875.28}, {"cat": "Técnico Polivalente", "jor": "8.0", "sm": 5744.26}, {"cat": "Técnico Electricista", "jor": "8.0", "sm": 6090.42}, {"cat": "Técnico Electrónico", "jor": "8.0", "sm": 6090.42}, {"cat": "Técnico Mecánico", "jor": "8.0", "sm": 6090.42}, {"cat": "Técnico Plomero", "jor": "8.0", "sm": 6090.42}, {"cat": "Técnico A en Aire Acondicionado y Refrigeración", "jor": "8.0", "sm": 6727.66}, {"cat": "Técnico A en Equipos Médicos", "jor": "8.0", "sm": 6727.66}, {"cat": "Técnico A en Fluidos y Energéticos", "jor": "8.0", "sm": 6727.66}, {"cat": "Técnico A en Plantas de Lavado", "jor": "8.0", "sm": 6727.66}, {"cat": "Técnico A en Telecomunicaciones", "jor": "8.0", "sm": 6727.66}, {"cat": "Técnico B en Equipos Médicos", "jor": "8.0", "sm": 7500.94}, {"cat": "Técnico B en Fluidos y Energéticos", "jor": "8.0", "sm": 7500.94}, {"cat": "Técnico B en Plantas de Lavado", "jor": "8.0", "sm": 7500.94}, {"cat": "Técnico B en Telecomunicaciones", "jor": "8.0", "sm": 7500.94}, {"cat": "Técnico en Equipos Reciprocantes", "jor": "8.0", "sm": 7500.94}, {"cat": "Técnico en Electrónica Médica y Laboratorio", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico C en Fluidos y Energéticos", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico C en Plantas de Lavado", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico C en Telecomunicaciones", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico en Mecánica, Fluidos y Especialidades", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico en Equipos de Absorción", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico en Equipos Helicoidal", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico en Equipos de Rayos X", "jor": "8.0", "sm": 8441.62}, {"cat": "Técnico en Equipos Turbocentrífugo", "jor": "8.0", "sm": 8441.62}, {"cat": "Especialista en Equipos de Especialidades", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Equipos de Laboratorio", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Equipos de Mecánica y Fluidos", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Equipos de Aire Acondicionado y Refrig.", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Plantas de Lavado", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Equipos de Electrónica Médica", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Equipos de Rayos X", "jor": "8.0", "sm": 9591.02}, {"cat": "Especialista en Fluidos y Energéticos", "jor": "8.0", "sm": 9591.02}, {"cat": "Arquitecto", "jor": "8.0", "sm": 11230.64}, {"cat": "Dibujante de Construcción", "jor": "6.5", "sm": 5831.5}, {"cat": "Dibujante de Construcción", "jor": "8.0", "sm": 7177.18}, {"cat": "Dibujante de Estadística y Publicidad C", "jor": "6.5", "sm": 4175.98}, {"cat": "Dibujante de Estadística y Publicidad B", "jor": "8.0", "sm": 5461.8}, {"cat": "Dibujante de Estadística y Publicidad A", "jor": "6.5", "sm": 5831.5}, {"cat": "Dibujante de Estadística y Publicidad A", "jor": "8.0", "sm": 7177.18}, {"cat": "Dibujante de Ingeniería y Arquitectura", "jor": "6.5", "sm": 5831.5}, {"cat": "Dibujante de Ingeniería y Arquitectura", "jor": "8.0", "sm": 7177.18}, {"cat": "Auxiliar de Almacén", "jor": "6.5", "sm": 4746.16}, {"cat": "Auxiliar de Almacén", "jor": "8.0", "sm": 5841.44}, {"cat": "Oficial de Almacén", "jor": "8.0", "sm": 7068.14}, {"cat": "Coordinador de Almacén", "jor": "8.0", "sm": 8340.48}, {"cat": "Jefe de Grupo de Almacén", "jor": "8.0", "sm": 10242.12}, {"cat": "Especialista de Almacén", "jor": "8.0", "sm": 11266.48}, {"cat": "Auxiliar de Servicios de Intendencia", "jor": "6.5", "sm": 3961.3}, {"cat": "Auxiliar de Servicios de Intendencia", "jor": "8.0", "sm": 4875.46}, {"cat": "Ayudante de Servicios de Intendencia", "jor": "8.0", "sm": 5648.58}, {"cat": "Oficial de Servicios de Intendencia", "jor": "8.0", "sm": 6098.68}, {"cat": "Intendente", "jor": "8.0", "sm": 6565.76}, {"cat": "Auxiliar de Limpieza e Higiene (Médicas y No Médicas)", "jor": "8.0", "sm": 4875.46}, {"cat": "Ayudante de Limpieza e Higiene (Médicas y No Médicas)", "jor": "8.0", "sm": 5648.58}, {"cat": "Auxiliar de Limpieza y Cocina en Unidad Médica", "jor": "6.5", "sm": 3990.86}, {"cat": "Auxiliar de Limpieza y Cocina en Unidad Médica", "jor": "8.0", "sm": 4911.82}, {"cat": "Auxiliar de Servicios Generales en Unidad Médica", "jor": "6.5", "sm": 4742.96}, {"cat": "Auxiliar de Servicios Generales en Unidad Médica", "jor": "8.0", "sm": 5837.3}, {"cat": "Operador de Servicios de Lavandería", "jor": "6.5", "sm": 4571.8}, {"cat": "Operador de Servicios de Lavandería", "jor": "8.0", "sm": 5626.62}, {"cat": "Oficial de Servicios de Lavandería", "jor": "6.5", "sm": 4935.84}, {"cat": "Oficial de Servicios de Lavandería", "jor": "8.0", "sm": 6074.84}, {"cat": "Manejador de Alimentos", "jor": "6.5", "sm": 3961.3}, {"cat": "Manejador de Alimentos", "jor": "8.0", "sm": 4875.46}, {"cat": "Cocinero Técnico 2", "jor": "6.5", "sm": 4589.44}, {"cat": "Cocinero Técnico 2", "jor": "8.0", "sm": 5648.58}, {"cat": "Cocinero Técnico 1", "jor": "6.5", "sm": 4955.02}, {"cat": "Cocinero Técnico 1", "jor": "8.0", "sm": 6098.68}, {"cat": "Chofer", "jor": "6.5", "sm": 4662.28}, {"cat": "Chofer", "jor": "8.0", "sm": 5738.04}, {"cat": "Motociclista", "jor": "6.5", "sm": 4662.28}, {"cat": "Motociclista", "jor": "8.0", "sm": 5738.04}, {"cat": "Controlador de Vehículos", "jor": "6.5", "sm": 5937.82}, {"cat": "Controlador de Vehículos", "jor": "8.0", "sm": 7308.0}, {"cat": "Enfermera para el Traslado de Pacientes de Urgencia", "jor": "8.0", "sm": 7381.12}, {"cat": "Enfermera para Traslado de Pacientes Terapia Intensiva", "jor": "8.0", "sm": 8415.48}, {"cat": "Técnico Operador Transporte Pacientes de Urgencia", "jor": "8.0", "sm": 7193.64}, {"cat": "Técnico Operador Transporte Pacientes Terapia Intens.", "jor": "8.0", "sm": 7783.54}, {"cat": "Médico para el Traslado de Pacientes de Urgencia", "jor": "8.0", "sm": 12844.2}, {"cat": "Médico para Traslado de Pacientes Terapia Intensiva", "jor": "8.0", "sm": 12844.2}, {"cat": "Camillero Vehículos Serv. Ord. y Prog. (D.F. y Valle)", "jor": "8.0", "sm": 5748.92}, {"cat": "Operador de Vehículos Serv. Ord. y Prog. (D.F. y Valle)", "jor": "8.0", "sm": 6766.56}, {"cat": "Operador de Ambulancias (Foráneo)", "jor": "6.5", "sm": 4998.14}, {"cat": "Operador de Ambulancias (Foráneo)", "jor": "8.0", "sm": 6151.64}, {"cat": "Controlador Vehículos Serv. Ord. y Prog.", "jor": "6.5", "sm": 5937.82}, {"cat": "Controlador Vehículos Serv. Ord. y Prog.", "jor": "8.0", "sm": 7308.0}, {"cat": "Camillero de Unidades Hospitalarias", "jor": "8.0", "sm": 5748.92}, {"cat": "Elevadorista", "jor": "6.5", "sm": 4154.86}, {"cat": "Elevadorista", "jor": "8.0", "sm": 5113.92}, {"cat": "Ayudante de Autopsia", "jor": "6.5", "sm": 5326.04}, {"cat": "Ayudante de Autopsia", "jor": "8.0", "sm": 6555.1}, {"cat": "Auxiliar de Farmacia", "jor": "6.5", "sm": 5220.34}, {"cat": "Auxiliar de Farmacia", "jor": "8.0", "sm": 6424.6}, {"cat": "Ayudante de Farmacia", "jor": "8.0", "sm": 7180.26}, {"cat": "Oficial de Farmacia", "jor": "8.0", "sm": 8329.04}, {"cat": "Coordinador de Farmacia", "jor": "8.0", "sm": 9800.3}, {"cat": "Guardavidas", "jor": "6.5", "sm": 4571.8}, {"cat": "Heliografista", "jor": "8.0", "sm": 6673.96}, {"cat": "Técnico de Microfotografía", "jor": "8.0", "sm": 7875.28}, {"cat": "Machetero", "jor": "6.5", "sm": 4071.5}, {"cat": "Machetero", "jor": "8.0", "sm": 5011.44}, {"cat": "Masajista", "jor": "6.5", "sm": 3908.44}, {"cat": "Multilitista", "jor": "6.5", "sm": 5209.52}, {"cat": "Multilitista", "jor": "8.0", "sm": 6411.42}, {"cat": "Operador de Equipo A (Intercom. Neumática)", "jor": "6.5", "sm": 6442.26}, {"cat": "Operador de Máquinas de Revelado Automático", "jor": "8.0", "sm": 5626.62}, {"cat": "Peluquero", "jor": "8.0", "sm": 4963.88}, {"cat": "Preparador de mezclas", "jor": "8.0", "sm": 11230.64}, {"cat": "Operador Telefónico A", "jor": "6.5", "sm": 4667.16}, {"cat": "Operador Telefónico A", "jor": "8.0", "sm": 5744.26}, {"cat": "Operador Telefónico B", "jor": "8.0", "sm": 6678.82}, {"cat": "Operador Telefónico C", "jor": "8.0", "sm": 7844.5}, {"cat": "Coordinador de Operadores Telefónicos", "jor": "8.0", "sm": 9308.32}, {"cat": "Operador General en Tiendas", "jor": "8.0", "sm": 5841.44}, {"cat": "Jefe de Línea en Tiendas", "jor": "8.0", "sm": 6226.66}, {"cat": "Auxiliar de Velatorio", "jor": "8.0", "sm": 4880.0}, {"cat": "Operador de Velatorio", "jor": "8.0", "sm": 5738.04}, {"cat": "Ayudante de Embalsamamiento", "jor": "8.0", "sm": 6136.0}, {"cat": "Yesista", "jor": "8.0", "sm": 5744.26}, {"cat": "Cuidador de Animales", "jor": "8.0", "sm": 5626.62}, {"cat": "Técnico de Bibliotecas", "jor": "6.5", "sm": 5589.56}, {"cat": "Técnico de Bibliotecas", "jor": "8.0", "sm": 6879.38}, {"cat": "Asistente de Bibliotecario", "jor": "6.5", "sm": 7396.12}, {"cat": "Asistente de Bibliotecario", "jor": "8.0", "sm": 9103.14}, {"cat": "Bibliotecario", "jor": "6.5", "sm": 9125.04}, {"cat": "Bibliotecario", "jor": "8.0", "sm": 11230.64}, {"cat": "Biólogo", "jor": "8.0", "sm": 11230.64}, {"cat": "Auxiliar de Administración de C.V.", "jor": "8.0", "sm": 5744.26}, {"cat": "Auxiliar de Atención Médica de C.V.", "jor": "8.0", "sm": 5697.86}, {"cat": "Auxiliar de Hospedaje de C.V.", "jor": "8.0", "sm": 5787.78}, {"cat": "Auxiliar de Operación Contable de C.V.", "jor": "8.0", "sm": 6678.82}, {"cat": "Lavandero en Centros Vacacionales", "jor": "8.0", "sm": 5626.62}, {"cat": "Operador de Seguridad en Albercas de C.V.", "jor": "8.0", "sm": 5626.62}, {"cat": "Operador de Servicios Internos de C.V.", "jor": "8.0", "sm": 4875.46}, {"cat": "Operador de Vehículos de C.V.", "jor": "8.0", "sm": 5738.04}, {"cat": "Planchador en Centros Vacacionales", "jor": "8.0", "sm": 5626.62}, {"cat": "Vigilante de Centros Vacacionales", "jor": "8.0", "sm": 4875.46}, {"cat": "Educadora", "jor": "6.0", "sm": 5469.06}, {"cat": "Educadora", "jor": "6.5", "sm": 5924.68}, {"cat": "Educadora", "jor": "8.0", "sm": 7291.94}, {"cat": "Oficial de Puericultura", "jor": "6.5", "sm": 4667.16}, {"cat": "Oficial de Puericultura", "jor": "8.0", "sm": 5744.26}, {"cat": "Técnico de Puericultura", "jor": "8.0", "sm": 6230.44}, {"cat": "Orientador", "jor": "6.5", "sm": 6557.9}, {"cat": "Orientador", "jor": "8.0", "sm": 8071.42}, {"cat": "Orientador de Actividades Familiares", "jor": "20.0", "sm": 4116.02}, {"cat": "Orientador Actividades Artísticas (Clásica/Moderna)", "jor": "20.0", "sm": 3531.36}, {"cat": "Orientador Actividades Artísticas (Danza Regional)", "jor": "20.0", "sm": 3767.66}, {"cat": "Orientador Actividades Artísticas (Maestro Música)", "jor": "20.0", "sm": 3531.36}, {"cat": "Orientador Actividades Artísticas (Arte Dramático)", "jor": "20.0", "sm": 3874.68}, {"cat": "Orientador de Educación Física", "jor": "20.0", "sm": 4154.68}, {"cat": "Orientador de Iniciación Cultural", "jor": "20.0", "sm": 3531.36}, {"cat": "Orientador Técnico Médico", "jor": "20.0", "sm": 5820.22}, {"cat": "Auxiliar de Orientador Técnico Médico", "jor": "6.5", "sm": 4054.16}, {"cat": "Pianista", "jor": "1.5", "sm": 3291.18}, {"cat": "Profesor de Educación Física A", "jor": "4.0", "sm": 4127.42}, {"cat": "Profesor de Educación Física A", "jor": "6.0", "sm": 5332.22}, {"cat": "Profesor de Educación Física A", "jor": "8.0", "sm": 7109.82}, {"cat": "Profesor de Educación Física B", "jor": "4.0", "sm": 4604.38}, {"cat": "Profesor de Educación Física B", "jor": "6.0", "sm": 6047.7}, {"cat": "Profesor de Educación Física B", "jor": "8.0", "sm": 8063.58}, {"cat": "Profesor de Educación Física C", "jor": "4.0", "sm": 5182.08}, {"cat": "Profesor de Educación Física C", "jor": "6.0", "sm": 6914.4}, {"cat": "Profesor de Educación Física C", "jor": "8.0", "sm": 9219.34}, {"cat": "Promotor de Estomatología", "jor": "8.0", "sm": 11230.64}, {"cat": "Promotor de Salud Comunitaria", "jor": "8.0", "sm": 7068.14}, {"cat": "Aux. de Administración (Esquema Modificado y Campo)", "jor": "8.0", "sm": 5917.9}, {"cat": "Aux. de Atención Médica (Esquema Modificado y Campo)", "jor": "8.0", "sm": 6108.68}, {"cat": "Auxiliar de Laboratorio (Esquema Modificado y Campo)", "jor": "8.0", "sm": 6309.58}, {"cat": "Aux. Servicios Generales (Esquema Modificado y Campo)", "jor": "8.0", "sm": 4990.68}, {"cat": "Estomatólogo (Esquema Modificado y Campo)", "jor": "6.0", "sm": 8869.12}, {"cat": "Operador Serv. Radiodiagnóstico (Esq. Mod. y Campo)", "jor": "8.0", "sm": 6309.58}, {"cat": "Auxiliar de Administración (Unidad Médica de Campo)", "jor": "8.0", "sm": 5917.9}, {"cat": "Auxiliar de Área Médica (Unidad Médica de Campo)", "jor": "8.0", "sm": 6108.68}, {"cat": "Aux. de Servicios Generales (Unidad Médica de Campo)", "jor": "8.0", "sm": 4990.68}, {"cat": "Estomatólogo en Unidad Médica de Campo", "jor": "8.0", "sm": 7748.32}, {"cat": "Operador de Mantenimiento (Unidad Médica de Campo)", "jor": "8.0", "sm": 4990.68}, {"cat": "Operador Servicios Auxiliares Laboratorio (U.M. Campo)", "jor": "8.0", "sm": 6309.58}, {"cat": "Operador Servicios Auxiliares Rayos X (U.M. Campo)", "jor": "8.0", "sm": 6309.58}, {"cat": "Auxiliar de Administración en H.R.", "jor": "8.0", "sm": 5917.9}, {"cat": "Auxiliar de Área Médica en H.R.", "jor": "8.0", "sm": 6108.68}, {"cat": "Auxiliar de Enfermería General en H.R.", "jor": "8.0", "sm": 6108.68}, {"cat": "Auxiliar de Enfermería General en U.M.R.", "jor": "8.0", "sm": 6108.68}, {"cat": "Auxiliar de Servicios Generales en H.R.", "jor": "8.0", "sm": 4990.68}, {"cat": "Citotecnólogo en H.R.", "jor": "8.0", "sm": 7337.54}, {"cat": "Enfermera Especialista Quirúrgica H.R.", "jor": "8.0", "sm": 8415.48}, {"cat": "Enfermera General en H.R.", "jor": "8.0", "sm": 7310.08}, {"cat": "Enfermera General Clínica en Unidad del Programa", "jor": "8.0", "sm": 7898.3}, {"cat": "Estomatólogo en H.R.", "jor": "8.0", "sm": 11924.12}, {"cat": "Laboratorista en H.R.", "jor": "8.0", "sm": 8349.78}, {"cat": "Médico General en U.M.C.", "jor": "8.0", "sm": 9751.8}, {"cat": "Médico No Familiar H.R.", "jor": "8.0", "sm": 12844.2}, {"cat": "Nutricionista Dietista en H.R.", "jor": "8.0", "sm": 7310.08}, {"cat": "Oficial de Conservación en H.R.", "jor": "8.0", "sm": 5709.56}, {"cat": "Operador de Mantenimiento en H.R.", "jor": "8.0", "sm": 5709.56}, {"cat": "Operador de Serv. Auxiliares (Laboratorio) en H.R.", "jor": "8.0", "sm": 6309.58}, {"cat": "Operador de Serv. Auxiliares (Radiodiagnóstico) en H.R.", "jor": "8.0", "sm": 6309.58}, {"cat": "Persona usuariaa Social en H.R.", "jor": "8.0", "sm": 7310.08}, {"cat": "Residente (R1)", "jor": "", "sm": 2810.74}, {"cat": "Residente (R2)", "jor": "", "sm": 3042.46}, {"cat": "Residente (R3)", "jor": "", "sm": 3119.54}, {"cat": "Residente (R4)", "jor": "", "sm": 3197.52}, {"cat": "Residente (R5)", "jor": "", "sm": 3293.5}, {"cat": "Residente (R6)", "jor": "", "sm": 3392.26}, {"cat": "Residente (R7)", "jor": "", "sm": 3494.16}, {"cat": "Residente (R8)", "jor": "", "sm": 3598.82}];
 
@@ -406,18 +406,18 @@
   searchInput.addEventListener('input', function() {
     closeLists();
     if (!this.value) return;
-    
+
     let a = document.createElement("DIV");
     a.setAttribute("class", "autocomplete-items");
     this.parentNode.appendChild(a);
-    
+
     let searchVal = removeAccents(this.value.toLowerCase());
-    
+
     let matches = sueldosDB.filter(i => {
       let catNorm = removeAccents(i.cat.toLowerCase());
       return catNorm.includes(searchVal);
     }).slice(0, 15);
-    
+
     matches.forEach(item => {
       let b = document.createElement("DIV");
       b.innerHTML = `<div><strong>${item.cat}</strong> <span style="color:var(--muted); font-size:0.85rem;">(${item.jor} hrs)</span></div><div style="color:var(--primary); font-weight:bold;">${money(item.sm / 2)} <span style="font-size:0.7rem; font-weight:normal;">/qna</span></div>`;
@@ -440,18 +440,18 @@
   // -------------------------------------------------------------
   function seleccionarPuesto(item) {
     searchInput.value = `${item.cat} (${item.jor} hrs)`;
-    
+
     // Guardamos el Sueldo Tabular MENSUAL para las matemáticas
     userData.tabular_mensual = item.sm;
-    userData.jornada = parseFloat(item.jor) || 8; 
+    userData.jornada = parseFloat(item.jor) || 8;
     userData.categoria = item.cat;
-    
+
     // Mostramos al usuario su Tabular QUINCENAL (La mitad del mensual)
     let tabular_quincenal = item.sm / 2;
     document.getElementById('ud-cat').innerText = item.cat;
     document.getElementById('ud-jor').innerText = item.jor || '-';
     document.getElementById('ud-tab').innerText = money(tabular_quincenal);
-    
+
     updateRentaGlobal(); // Re-validamos renta si ya había algo escrito
     document.getElementById('user-data').classList.add('active');
   }
@@ -460,14 +460,14 @@
   function updateRentaGlobal() {
     let inputRenta = document.getElementById('ud-renta');
     let val = parseFloat(inputRenta.value);
-    
+
     if (isNaN(val) || val < 0) {
       alert("¡Cuidado! El monto de la Ayuda de Renta no parece válido. Por favor ingresa solo números (ej. 500 o 1200.50).");
       inputRenta.value = 0;
       userData.renta_quincenal = 0;
     } else if (val > 5000) {
       alert("Ese monto parece demasiado alto para ser la ayuda de renta de UNA SOLA QUINCENA. Verifica en tu tarjetón que no estés poniendo un monto de otro concepto.");
-      userData.renta_quincenal = val; 
+      userData.renta_quincenal = val;
     } else {
       userData.renta_quincenal = val;
     }
@@ -505,7 +505,7 @@
     if (!validarDatos()) return;
     const sueldo = getSueldoMensualBase();
     const meses = parseInt(document.getElementById('ant_meses').value);
-    
+
     const monto = sueldo * meses;
     const plazo = meses * 10;
     const desc = monto / plazo;
@@ -522,7 +522,7 @@
   function calcAhorro() {
     if (!validarDatos()) return;
     const diasLab = parseFloat(document.getElementById('aho_dias').value) || 0;
-    
+
     const salarioDiario = userData.tabular_mensual / 30;
     const diasPagar = 46 * (diasLab / 365);
     const total = salarioDiario * diasPagar;
@@ -539,7 +539,7 @@
     if (!validarDatos()) return;
     const horas = parseFloat(document.getElementById('ext_horas').value) || 0;
     const factor = parseInt(document.getElementById('ext_factor').value);
-    
+
     const costoHora = getSueldoMensualBase() / 30 / userData.jornada;
     const total = costoHora * factor * horas;
 
@@ -561,8 +561,8 @@
   // -------------------------------------------------------------
   function calcHipoLargo() {
     if (!validarDatos()) return;
-    const liq = parseInt(document.getElementById('hl_liq').value); 
-    
+    const liq = parseInt(document.getElementById('hl_liq').value);
+
     const smi = getSueldoMensualBase() * 1.20;
     const max = smi * liq;
     const porcentaje = getPorcentajeHipotecario();
@@ -578,7 +578,7 @@
   // -------------------------------------------------------------
   function calcHipoMedio() {
     if (!validarDatos()) return;
-    
+
     const smi = getSueldoMensualBase() * 1.20;
     const max = smi * 35;
     const porcentaje = getPorcentajeHipotecario();
@@ -594,7 +594,7 @@
   // -------------------------------------------------------------
   function calcAuto() {
     if (!validarDatos()) return;
-    
+
     const smi = getSueldoMensualBase() * 1.20;
     const max = smi * 24;
 
@@ -604,7 +604,7 @@
     document.getElementById('au_y3').innerText = "-" + money((smi * 0.38) / 2);
     document.getElementById('au_y4').innerText = "-" + money((smi * 0.37) / 2);
     document.getElementById('au_y5').innerText = "-" + money((smi * 0.36) / 2);
-    
+
     document.getElementById('res_auto').classList.add('active');
   }
 
@@ -614,7 +614,7 @@
   function calcAguinaldo() {
     if (!validarDatos()) return;
     const pideAgosto = document.getElementById('ag_agosto').value === 'si';
-    
+
     const sueldo = getSueldoMensualBase();
     const total = sueldo * 3;
     const enero = sueldo * 0.5;
@@ -623,14 +623,14 @@
 
     document.getElementById('ag_total').innerText = money(total);
     document.getElementById('ag_enero').innerText = money(enero);
-    
+
     if (pideAgosto) {
       document.getElementById('row_agosto').style.display = 'flex';
       document.getElementById('ag_ago_val').innerText = money(agosto);
     } else {
       document.getElementById('row_agosto').style.display = 'none';
     }
-    
+
     document.getElementById('ag_dic').innerText = money(dic);
     document.getElementById('res_aguinaldo').classList.add('active');
   }

--- a/requisitos_tramites.html
+++ b/requisitos_tramites.html
@@ -11,15 +11,15 @@
     <style>
         /* ===== PALETA PSD (Colores de la Plataforma) ===== */
         :root {
-            --bg-body: #1b2e45; 
-            --bg-body-end: #152336;
+            --bg-body: #004b33;
+            --bg-body-end: #003423;
             --panel-base: 46, 79, 119;
-            --primary: #4da1a8; 
-            --primary-light: #7ad1d6;
+            --primary: #006341;
+            --primary-light: #8fd9b6;
             --success: #4ade80;
-            --text-main: #f0fdfa; 
+            --text-main: #f0fdfa;
             --text-muted: #bce9eb;
-            --ring: rgba(77, 161, 168, .35);
+            --ring: rgba(0, 99, 65, .35);
             --glass-bg: rgba(var(--panel-base), 0.35);
         }
 
@@ -27,18 +27,18 @@
             font-family: 'Inter', sans-serif;
             background-color: transparent; /* Transparente para que tome el fondo del iframe */
             color: var(--text-main);
-            padding: 1rem; 
+            padding: 1rem;
         }
 
         /* ===== ENCABEZADO ===== */
         .page-header {
-            background: linear-gradient(135deg, rgba(77, 161, 168, 0.2), rgba(var(--panel-base), 0.6));
+            background: linear-gradient(135deg, rgba(0, 99, 65, 0.2), rgba(var(--panel-base), 0.6));
             border: 1px solid var(--primary-light);
             color: var(--text-main);
             padding: 2rem 1.5rem;
             border-radius: 12px;
             margin-bottom: 2rem;
-            box-shadow: 0 8px 24px rgba(77, 161, 168, 0.15);
+            box-shadow: 0 8px 24px rgba(0, 99, 65, 0.15);
         }
         .page-header h2 {
             font-weight: 800;
@@ -66,7 +66,7 @@
             overflow: hidden;
             transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
-        
+
         .accordion-item:hover {
             transform: translateY(-2px);
             border-color: var(--primary);
@@ -81,18 +81,18 @@
             background: transparent;
             border-radius: 12px !important;
         }
-        
+
         .accordion-button:not(.collapsed) {
             color: var(--text-main);
             background: rgba(var(--panel-base), 0.6);
-            box-shadow: inset 0 -1px 0 rgba(77, 161, 168, 0.2);
+            box-shadow: inset 0 -1px 0 rgba(0, 99, 65, 0.2);
         }
 
         .accordion-button:focus {
             box-shadow: none;
-            border-color: rgba(77, 161, 168, 0.5);
+            border-color: rgba(0, 99, 65, 0.5);
         }
-        
+
         .accordion-button::after {
             filter: brightness(0) invert(1); /* Pone la flecha en blanco */
         }
@@ -101,9 +101,9 @@
             font-size: 1.3rem;
             margin-right: 12px;
             color: var(--primary-light);
-            filter: drop-shadow(0 2px 4px rgba(77, 161, 168, 0.4));
+            filter: drop-shadow(0 2px 4px rgba(0, 99, 65, 0.4));
         }
-        
+
         .accordion-button:not(.collapsed) i.icon-title {
             color: var(--success);
             filter: drop-shadow(0 2px 4px rgba(74, 222, 128, 0.4));
@@ -127,13 +127,13 @@
             margin-bottom: 1.5rem;
             color: var(--text-main);
         }
-        
+
         .req-list li {
             margin-bottom: 0.4rem;
         }
 
         .info-box {
-            background-color: rgba(77, 161, 168, 0.1);
+            background-color: rgba(0, 99, 65, 0.1);
             border-left: 4px solid var(--success);
             padding: 1rem;
             border-radius: 0 8px 8px 0;
@@ -177,7 +177,7 @@
             color: var(--text-main);
             box-shadow: inset 0 2px 5px rgba(0,0,0,0.2);
         }
-        
+
         .search-input::placeholder {
             color: rgba(188, 233, 235, 0.6); /* --text-muted con opacidad */
         }
@@ -186,9 +186,9 @@
             background: rgba(var(--panel-base), 0.7);
             color: var(--text-main);
             border-color: var(--primary-light);
-            box-shadow: 0 0 0 0.25rem rgba(77, 161, 168, 0.25);
+            box-shadow: 0 0 0 0.25rem rgba(0, 99, 65, 0.25);
         }
-        
+
         .input-group-text {
             background: rgba(var(--panel-base), 0.5);
             border: 1px solid var(--ring);
@@ -199,7 +199,7 @@
 <body>
 
     <div class="container-fluid px-0">
-        
+
         <div class="page-header">
             <h2><i class="bi bi-file-earmark-text"></i> Catálogo de Trámites</h2>
             <p>Sección XX - Atención directa y sin intermediarios.</p>
@@ -218,7 +218,7 @@
 
             <h3 class="category-title"><i class="bi bi-people-fill"></i> Igualdad Sustantiva y Familia</h3>
             <div class="accordion" id="accIgualdad">
-                
+
                 <div class="accordion-item tramite-item">
                     <h2 class="accordion-header">
                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#t1">
@@ -289,8 +289,8 @@
                     </div>
                 </div>
 
-            </div> 
-            
+            </div>
+
             <h3 class="category-title"><i class="bi bi-shield-check"></i> Previsión Social y Habitación</h3>
             <div class="accordion" id="accPrevision">
 
@@ -451,11 +451,11 @@
                     </div>
                 </div>
 
-            </div> 
-            
+            </div>
+
             <h3 class="category-title"><i class="bi bi-mortarboard"></i> Desarrollo Académico y Capacitación</h3>
             <div class="accordion" id="accDesarrollo">
-                
+
                 <div class="accordion-item tramite-item">
                     <h2 class="accordion-header">
                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#t12">
@@ -497,11 +497,11 @@
                     </div>
                 </div>
 
-            </div> 
-            
+            </div>
+
             <h3 class="category-title"><i class="bi bi-heart-pulse"></i> Prestaciones Médicas Adicionales</h3>
             <div class="accordion" id="accMedicos">
-                
+
                 <div class="accordion-item tramite-item">
                     <h2 class="accordion-header">
                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#t14">
@@ -523,12 +523,12 @@
                     </div>
                 </div>
 
-            </div> 
-        </div> 
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    
+
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const searchInput = document.getElementById('searchInput');
@@ -550,7 +550,7 @@
                 document.querySelectorAll('.accordion').forEach(acc => {
                     const parentTitle = acc.previousElementSibling;
                     const visibleItems = Array.from(acc.querySelectorAll('.tramite-item')).filter(i => i.style.display !== 'none');
-                    
+
                     if (visibleItems.length === 0) {
                         parentTitle.style.display = 'none';
                     } else {

--- a/reservas.html
+++ b/reservas.html
@@ -7,20 +7,20 @@
   <link rel="icon" href="https://github.com/ChronosBVRX/PlataformaComunitaria/blob/main/Logo%20Unidad%20en%20Accion.png?raw=true">
   <style>
     :root{
-      --bg:#1b2e45;
+      --bg:#004b33;
       --panel:#2e4f77;
-      --ring:rgba(77,161,168,.45);
+      --ring:rgba(0,99,65,.45);
       --txt:#f0fdfa;
       --muted:#bce9eb;
-      --primary:#4da1a8;
-      --sky:#7ad1d6;
+      --primary:#006341;
+      --sky:#8fd9b6;
       --danger:#ff5b5b;
     }
     *{box-sizing:border-box;margin:0;padding:0;font-family:system-ui,-apple-system,Segoe UI,Roboto}
 
     body{
       min-height:100vh;
-      background:linear-gradient(180deg,#152336,#1b2e45);
+      background:linear-gradient(180deg,#003423,#004b33);
       color:var(--txt);
       display:flex;flex-direction:column;
       overflow-x:hidden;
@@ -38,7 +38,7 @@
       padding:10px 16px;
       background:rgba(30,50,80,.75);
       backdrop-filter:blur(8px);
-      border-bottom:1px solid rgba(77,161,168,.35)
+      border-bottom:1px solid rgba(0,99,65,.35)
     }
     header img{height:40px}
     header h1{font-size:18px;color:#dcfce7;display:flex;align-items:center;gap:10px}
@@ -54,12 +54,12 @@
     nav{
       width:260px;
       background:rgba(27,46,69,.85);
-      border-right:1px solid rgba(77,161,168,.25);
+      border-right:1px solid rgba(0,99,65,.25);
       padding:12px;display:flex;flex-direction:column;gap:10px;
       flex-shrink:0;
     }
     nav button{
-      border:none;background:rgba(77,161,168,.12);
+      border:none;background:rgba(0,99,65,.12);
       color:var(--txt);
       padding:10px;border-radius:10px;text-align:left;
       cursor:pointer;transition:.2s
@@ -74,7 +74,7 @@
 
     .card{
       background:var(--panel);
-      border:1px solid rgba(77,161,168,.35);
+      border:1px solid rgba(0,99,65,.35);
       border-radius:16px;
       padding:20px;
       box-shadow:0 8px 25px rgba(0,0,0,.25);
@@ -86,7 +86,7 @@
     .muted{color:var(--muted)}
     .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
     input, textarea, select{
-      background:#1b2e45;border:1px solid rgba(77,161,168,.4);
+      background:#004b33;border:1px solid rgba(0,99,65,.4);
       color:#f0fdfa;padding:9px 11px;border-radius:10px
     }
     textarea{min-height:90px;resize:vertical}
@@ -99,12 +99,12 @@
     }
     .btn:hover{filter:brightness(1.12)}
     .subtle-btn{
-      border:1px solid rgba(77,161,168,.28);
-      background:rgba(77,161,168,.1);
+      border:1px solid rgba(0,99,65,.28);
+      background:rgba(0,99,65,.1);
       color:#fff;padding:8px 12px;border-radius:10px;
       cursor:pointer;font-size:13px
     }
-    .subtle-btn:hover{background:rgba(77,161,168,.25)}
+    .subtle-btn:hover{background:rgba(0,99,65,.25)}
     .danger-btn{
       border:1px solid rgba(255,90,90,.35);
       background:rgba(255,90,90,.12);
@@ -125,23 +125,23 @@
     }
     .asset-card{
       background:#233b5c;
-      border:1px solid rgba(77,161,168,.30);
+      border:1px solid rgba(0,99,65,.30);
       border-radius:14px;
       overflow:hidden;
       display:flex;flex-direction:column
     }
     .asset-img{
-      height:150px;background:#1b2e45;
+      height:150px;background:#004b33;
       display:flex;align-items:center;justify-content:center;
-      border-bottom:1px solid rgba(77,161,168,.25)
+      border-bottom:1px solid rgba(0,99,65,.25)
     }
     .asset-img img{width:100%;height:100%;object-fit:cover}
     .asset-body{padding:12px}
     .pill{
       display:inline-flex;align-items:center;gap:6px;
       padding:4px 8px;border-radius:999px;
-      background:rgba(77,161,168,.15);
-      border:1px solid rgba(77,161,168,.35);
+      background:rgba(0,99,65,.15);
+      border:1px solid rgba(0,99,65,.35);
       font-size:12px;color:#d1f5f7
     }
     .slots{
@@ -151,7 +151,7 @@
     }
     .slot{
       background:#233b5c;
-      border:1px solid rgba(77,161,168,.28);
+      border:1px solid rgba(0,99,65,.28);
       border-radius:12px;
       padding:10px 12px;
       display:flex;justify-content:space-between;align-items:center;gap:10px
@@ -179,11 +179,11 @@
       flex-direction: column;
       align-items: center;
       padding-top: 15%; /* Espacio superior */
-      border-radius: 16px; 
+      border-radius: 16px;
     }
     .locked-box {
       position: sticky; /* Se mantiene en pantalla al hacer scroll */
-      top: 30%; 
+      top: 30%;
       background: rgba(30, 50, 80, 0.95);
       border: 1px solid var(--sky);
       padding: 20px 30px;
@@ -407,7 +407,7 @@
               <button class="danger-btn" type="button" id="btnDeleteAsset" style="display:none">🗑️ Eliminar</button>
             </div>
 
-            <div class="card" style="background:#1b2e45;border-radius:12px">
+            <div class="card" style="background:#004b33;border-radius:12px">
               <div style="font-weight:800">🖼️ Foto principal (Storage bucket: assets)</div>
               <div class="meta" style="margin-top:6px">Se sube como <code>asset_id/portada.jpg</code> y se guarda el URL en el activo.</div>
               <input id="assetPhoto" type="file" accept="image/png,image/jpeg,image/webp">
@@ -445,7 +445,7 @@
             <div class="meta" id="blockStatus"></div>
           </form>
 
-          <div class="card" style="margin-top:12px;background:#1b2e45;border-radius:12px">
+          <div class="card" style="margin-top:12px;background:#004b33;border-radius:12px">
             <div style="font-weight:800">Lista de bloqueos próximos</div>
             <div id="blocksList" class="meta" style="margin-top:8px">—</div>
           </div>
@@ -774,7 +774,7 @@
     times.forEach(t=>{
       const slotStart = combineDateTimeLocal(dateISO, t);
       const slotEndRaw = addMinutes(slotStart, slotMin);
-      const slotEnd = addMinutes(slotEndRaw, bufMin); 
+      const slotEnd = addMinutes(slotEndRaw, bufMin);
 
       const isBusy = busy.some(r => overlaps(slotStart, slotEnd, r.start_at, r.end_at));
 
@@ -807,7 +807,7 @@
           return;
         }
 
-        PENDING_RESERVE = { start_at: slotStart, end_at: slotEndRaw }; 
+        PENDING_RESERVE = { start_at: slotStart, end_at: slotEndRaw };
         $("detailBox").textContent = `Vas a reservar: ${a.name} el ${dateISO} de ${t} a ${fmtHM(slotEndRaw)}.`;
         $("reserveWhen").textContent = `📌 ${fmtDT(slotStart)} – ${fmtDT(slotEndRaw)}`;
         $("reserveStatus").textContent = "";

--- a/reset-password.html
+++ b/reset-password.html
@@ -7,8 +7,8 @@
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <style>
   :root{
-    --bg:#0b1022; --panel:#0e1730; --ring:rgba(91,215,242,.35);
-    --txt:#e6fbff; --muted:#aee9f7; --accent:#5bd7f2; --sky:#60a5fa; --err:#ff7b7b;
+    --bg:#032a1d; --panel:#0e1730; --ring:rgba(0,168,107,.35);
+    --txt:#e6fbff; --muted:#aee9f7; --accent:#00a86b; --sky:#4caf7d; --err:#ff7b7b;
   }
   *{box-sizing:border-box}
   html,body{
@@ -16,30 +16,30 @@
     font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;
     background:
       radial-gradient(70vmax 70vmax at 50% 20%, rgba(96,165,250,.12), transparent 60%),
-      radial-gradient(60vmax 60vmax at 80% 80%, rgba(91,215,242,.10), transparent 60%),
-      linear-gradient(180deg,#0b1220,#0b1022);
+      radial-gradient(60vmax 60vmax at 80% 80%, rgba(0,168,107,.10), transparent 60%),
+      linear-gradient(180deg,#033123,#032a1d);
   }
   .wrap{max-width:480px;margin:0 auto;padding:22px}
   .card{
     margin-top:40px;
     background:linear-gradient(180deg,var(--panel),#0b1328);
-    border:1px solid rgba(91,215,242,.25); border-radius:16px; padding:20px;
+    border:1px solid rgba(0,168,107,.25); border-radius:16px; padding:20px;
     box-shadow:0 10px 40px rgba(0,0,0,.45);
   }
   .head{display:flex;align-items:center;gap:12px;margin-bottom:10px}
   .head img{
-    width:42px;height:42px;border-radius:10px;border:1px solid rgba(91,215,242,.25);
+    width:42px;height:42px;border-radius:10px;border:1px solid rgba(0,168,107,.25);
     background:#071022;object-fit:contain
   }
   h1{margin:0;font-size:18px;color:#d8fbff}
   .muted{color:#aee9f7;font-size:13px}
   label{display:block;font-size:12px;color:#bdefff;margin:10px 0 4px}
   input{
-    width:100%;padding:10px 12px;border-radius:12px;border:1px solid rgba(91,215,242,.28);
+    width:100%;padding:10px 12px;border-radius:12px;border:1px solid rgba(0,168,107,.28);
     background:#0a1329;color:#e6fbff;outline:none
   }
   .btn{
-    appearance:none;border:1px solid rgba(91,215,242,.45);background:rgba(91,215,242,.14);
+    appearance:none;border:1px solid rgba(0,168,107,.45);background:rgba(0,168,107,.14);
     color:#e6fbff;border-radius:12px;padding:10px 14px;font-size:14px;cursor:pointer;
     width:100%;margin-top:14px;
   }

--- a/scanner.html
+++ b/scanner.html
@@ -13,22 +13,22 @@
   <style>
     :root{
       /* ✅ IDENTIDAD VISUAL (Estricta) */
-      --bg:#1b2e45;
-      --bg2:#152336;
+      --bg:#004b33;
+      --bg2:#003423;
 
       --card:#2e4f77;                 /* Paneles/Tarjetas */
-      --primary:#4da1a8;              /* Acento principal */
-      --sky:#7ad1d6;                  /* Acento claro */
+      --primary:#006341;              /* Acento principal */
+      --sky:#8fd9b6;                  /* Acento claro */
       --txt:#f0fdfa;                  /* Texto principal */
       --muted:#bce9eb;                /* Texto secundario */
-      --ring: rgba(77,161,168,.35);   /* Bordes/anillos */
+      --ring: rgba(0,99,65,.35);   /* Bordes/anillos */
 
       /* Premium tokens (derivados de la paleta, sin salirte) */
       --glass: rgba(46,79,119,.72);
       --glass2: rgba(46,79,119,.55);
       --shadow: 0 18px 40px rgba(0,0,0,.34);
       --shadow2: 0 10px 22px rgba(0,0,0,.26);
-      --glow: 0 0 0 4px rgba(77,161,168,.14), 0 0 28px rgba(77,161,168,.18);
+      --glow: 0 0 0 4px rgba(0,99,65,.14), 0 0 28px rgba(0,99,65,.18);
 
       --dangerBg: rgba(255, 120, 120, .14);
       --dangerBorder: rgba(255, 140, 140, .28);
@@ -42,8 +42,8 @@
     body{
       min-height:100vh;
       background:
-        radial-gradient(900px 450px at 15% 10%, rgba(77,161,168,.12), transparent 60%),
-        radial-gradient(700px 380px at 85% 20%, rgba(122,209,214,.10), transparent 55%),
+        radial-gradient(900px 450px at 15% 10%, rgba(0,99,65,.12), transparent 60%),
+        radial-gradient(700px 380px at 85% 20%, rgba(143,217,182,.10), transparent 55%),
         linear-gradient(180deg,var(--bg),var(--bg2));
       color:var(--txt);
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial;
@@ -67,7 +67,7 @@
     .topTitle .dot{
       width:12px;height:12px;border-radius:999px;
       background: linear-gradient(180deg, var(--sky), var(--primary));
-      box-shadow: 0 0 0 6px rgba(77,161,168,.12);
+      box-shadow: 0 0 0 6px rgba(0,99,65,.12);
     }
     h2{
       font-size:22px;
@@ -118,7 +118,7 @@
       width:100%;
       padding:12px 12px;
       border-radius:14px;
-      border:1px solid rgba(77,161,168,.28);
+      border:1px solid rgba(0,99,65,.28);
       background: rgba(21,35,54,.45);
       color:var(--txt);
       outline:none;
@@ -127,7 +127,7 @@
     }
     input::placeholder{color:rgba(188,233,235,.72)}
     input:focus{
-      border-color: rgba(122,209,214,.60);
+      border-color: rgba(143,217,182,.60);
       box-shadow: var(--glow);
     }
 
@@ -148,7 +148,7 @@
     }
     .btnPrimary:hover{
       filter:brightness(1.06);
-      box-shadow: 0 12px 22px rgba(0,0,0,.25), 0 0 22px rgba(77,161,168,.18);
+      box-shadow: 0 12px 22px rgba(0,0,0,.25), 0 0 22px rgba(0,99,65,.18);
     }
     .btnPrimary:active{transform:scale(.99)}
 
@@ -170,9 +170,9 @@
       margin:12px auto 8px;
       border-radius:18px;
       overflow:hidden;
-      border:1px solid rgba(77,161,168,.30);
+      border:1px solid rgba(0,99,65,.30);
       background:
-        radial-gradient(600px 280px at 30% 20%, rgba(77,161,168,.10), transparent 60%),
+        radial-gradient(600px 280px at 30% 20%, rgba(0,99,65,.10), transparent 60%),
         rgba(0,0,0,.18);
       box-shadow: var(--shadow2);
     }
@@ -184,7 +184,7 @@
       gap:8px;
       padding:8px 10px;
       border-radius:999px;
-      border:1px solid rgba(77,161,168,.28);
+      border:1px solid rgba(0,99,65,.28);
       background: rgba(21,35,54,.35);
       color: rgba(240,253,250,.92);
       font-size:12.5px;
@@ -193,7 +193,7 @@
     .badge .spark{
       width:8px;height:8px;border-radius:999px;
       background: linear-gradient(180deg,var(--sky),var(--primary));
-      box-shadow: 0 0 0 5px rgba(77,161,168,.12);
+      box-shadow: 0 0 0 5px rgba(0,99,65,.12);
     }
   </style>
 </head>

--- a/theme.css
+++ b/theme.css
@@ -3,12 +3,12 @@
 
 :root {
   /* Palette */
-  --bg-dark: #050a14;
+  --bg-dark: #032117;
   --bg-panel: rgba(15, 23, 42, 0.65);
-  --primary: #5bd7f2;
+  --primary: #00a86b;
   --primary-glow: rgba(91, 215, 242, 0.4);
-  --secondary: #60a5fa;
-  --accent: #3b82f6;
+  --secondary: #4caf7d;
+  --accent: #2e8b57;
   --text-main: #e2e8f0;
   --text-muted: #94a3b8;
   --border: rgba(148, 163, 184, 0.15);

--- a/videollamadas.html
+++ b/videollamadas.html
@@ -11,8 +11,8 @@
       --panel: #020617;
       --txt: #e6fbff;
       --muted: #a5b4fc;
-      --primary: #5bd7f2;
-      --sky: #60a5fa;
+      --primary: #00a86b;
+      --sky: #4caf7d;
       --border: rgba(148, 163, 184, .6);
     }
 


### PR DESCRIPTION
### Motivation
- Standardize the platform visual identity to a new green palette and improve contrast across multiple pages and components. 
- Make a small UX/behavior change so specific external apps open outside the iframe when appropriate. 
- Clean up minor JS/CSS inconsistencies, whitespace and small presentation bugs found while updating the theme.

### Description
- Replaced color tokens and palette values (e.g. `--primary`, `--primary-light`, `--bg-body`, `--ring`) across many HTML and CSS files to a green theme (`#006341`, `#8fd9b6`, `#004b33` etc.), and adjusted derived rgba borders/shadows for consistency. 
- Updated component visuals (badges, buttons, card borders, backgrounds, progress bars, highlights) in multiple views including `index.html`, `buzon.html`, `biblioteca.html`, `kiosko.html`, `nucleo.html`, `perfil.html`, `miembros.html` and the shared CSS assets to use the new tokens. 
- Added `shouldOpenOutsideIframe(app)` in `index.html` and wired tile/open logic so selected apps (e.g. `perfil-imss`, `tarjeton`) open outside the iframe instead of being embedded, and set the page `theme-color` meta to match the new palette. 
- Minor JavaScript cleanups and small fixes across files: standardized checks for parent-supabase client usage, whitespace/formatting consistency, small UX tweaks (e.g. badge backgrounds, progress color adjustments, PDF preview handling), and tightened some security/authorization checks where present.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50b83fe108328990c13bf4ef5002f)